### PR TITLE
Develop

### DIFF
--- a/.github/workflows/compile-source.yml
+++ b/.github/workflows/compile-source.yml
@@ -14,6 +14,6 @@ jobs:
     - name: build-from-source
       #we need to get the official packet of DPI (not ready yet, 2022-02-22)
       run: |
-         wget https://github.com/Montimage/5Greplay/blob/4510092d028e5513f54bc5a40e838aa1debce2ed/lib/mmt-dpi_1.7.0.0_a8ad3c2_Linux_x86_64.deb
-         sudo dpkg -i mmt-dpi*.deb
+         wget -0 mmt-dpi.deb https://github.com/Montimage/5Greplay/blob/4510092d028e5513f54bc5a40e838aa1debce2ed/lib/mmt-dpi_1.7.0.0_a8ad3c2_Linux_x86_64.deb?raw=true
+         sudo dpkg -i mmt-dpi.deb
          make -j2

--- a/.github/workflows/compile-source.yml
+++ b/.github/workflows/compile-source.yml
@@ -1,0 +1,19 @@
+name: Compile source
+
+on:
+  push:
+    branches: [ develop ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: build-from-source
+      #we need to get the official packet of DPI (not ready yet, 2022-02-22)
+      run: |
+         wget https://github.com/Montimage/5Greplay/blob/4510092d028e5513f54bc5a40e838aa1debce2ed/lib/mmt-dpi_1.7.0.0_a8ad3c2_Linux_x86_64.deb
+         sudo dpkg -i mmt-dpi*.deb
+         make -j2

--- a/.github/workflows/compile-source.yml
+++ b/.github/workflows/compile-source.yml
@@ -16,4 +16,5 @@ jobs:
       run: |
          wget -O mmt-dpi.deb https://github.com/Montimage/5Greplay/blob/4510092d028e5513f54bc5a40e838aa1debce2ed/lib/mmt-dpi_1.7.0.0_a8ad3c2_Linux_x86_64.deb?raw=true
          sudo dpkg -i mmt-dpi.deb
+         sudo apt install -y git cmake gcc g++ cpp libconfuse-dev libpcap-dev libxml2-dev
          make -j2

--- a/.github/workflows/compile-source.yml
+++ b/.github/workflows/compile-source.yml
@@ -14,6 +14,6 @@ jobs:
     - name: build-from-source
       #we need to get the official packet of DPI (not ready yet, 2022-02-22)
       run: |
-         wget -0 mmt-dpi.deb https://github.com/Montimage/5Greplay/blob/4510092d028e5513f54bc5a40e838aa1debce2ed/lib/mmt-dpi_1.7.0.0_a8ad3c2_Linux_x86_64.deb?raw=true
+         wget -O mmt-dpi.deb https://github.com/Montimage/5Greplay/blob/4510092d028e5513f54bc5a40e838aa1debce2ed/lib/mmt-dpi_1.7.0.0_a8ad3c2_Linux_x86_64.deb?raw=true
          sudo dpkg -i mmt-dpi.deb
          make -j2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
+## v1.5.1
+- 24 Feb 2022
+- Support `proto.index.att` syntax in `event-report`
+- Add `delta-cond` in `event-report` to issue an report only if there is a change in a set of attributes
+- Improve `event-report` trigger mechanisme to be called only one when the whole packet is classified
+- Fixed bug when `output-channel` always containt `file-output`
+- Fixed bug that does not dump no-session packets to pcap files
+- Add all options/component when being packaged in a container
+- Add `. Aborted` word when explicitly aborting the current execution
+
 ## v1.5.0
 - 15 Feb 2022
 - Support any protocol stack. For example when `stack-type=178` the root protocol is IP (rather than Ethernet as by default)
 - Add `stack-offset` to ignore some prefixed bytes when analysing packet
+
 ## v1.4.4
 - 29 March 2021
 - Add `rtt-base` config parameter to decide which timestamp-base to calcultate RTT

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ APP = probe
 
 #get git version abbrev
 GIT_VERSION := $(shell git log --format="%h" -n 1)
-VERSION     := 1.5.0
+VERSION     := 1.5.1
 
 ifndef TOP_DIR
   #current directory

--- a/mmt-probe.conf
+++ b/mmt-probe.conf
@@ -341,7 +341,7 @@ event-report iot
 # inband-network telemetry
 event-report int
 {
-	enable = true
+	enable = false
 	event  = "int.latency"
 	#delta condition: only report info when there is a change in one of attributes'values indicated in "delta-cond"
 	# if all attributes are not available, the condition will not be checked, thus it is considered as no-change
@@ -355,9 +355,9 @@ event-report int
 #5G QoS Flow Identifier
 event-report qfi
 {
-	enable = true
-	event = "ip.2.src"
-	delta-cond = {"gtp.ext_pdu_qfi"}
-	attributes = {"gtp.ext_pdu_qfi", "ip.2.dst", "meta.packet_len"}
-	output-channel = {file}
+	enable = false
+	event = "gtp.ext_pdu_qfi"
+	delta-cond = {"ip.2.src", "ip.2.dst", "gtp.ext_pdu_qfi"}
+	attributes = {"ip.2.src", "ip.2.dst", "ip.1.src", "ip.1.dst", "ip.2.tot_len", "meta.packet_len"}
+	output-channel = {mongodb}
 }

--- a/mmt-probe.conf
+++ b/mmt-probe.conf
@@ -344,7 +344,8 @@ event-report int
 	enable = true
 	event  = "int.latency"
 	#delta condition: only report info when there is a change in one of attributes'values indicated in "delta-cond"
-	# if an attribute is not available, its value is 0
+	# if all attributes are not available, the condition will not be checked, thus it is considered as no-change
+	# if at least one attribute is available, the non-available attributes' values will be set to 0 or "" 
 	delta-cond = {"int.num_hop", "int.hop_switch_ids"}
 	attributes = {"ip.src", "ip.dst", "int.num_hop", "int.instruction_bits", 
 		"int.hop_switch_ids", "int.hop_latencies", "int.hop_queue_occups", "int.hop_ingress_times", "int.hop_egress_times"}
@@ -355,8 +356,8 @@ event-report int
 event-report qfi
 {
 	enable = true
-	event = "gtp.ext_pdu_qfi"
-	#delta-cond = {"gtp.ext_pdu_qfi"}
-	attributes = {"ip.src", "ip.dst", "meta.packet_len"}
+	event = "ip.2.src"
+	delta-cond = {"gtp.ext_pdu_qfi"}
+	attributes = {"gtp.ext_pdu_qfi", "ip.2.dst", "meta.packet_len"}
 	output-channel = {file}
 }

--- a/src/configure.c
+++ b/src/configure.c
@@ -553,7 +553,7 @@ static inline  output_channel_conf_t _parse_output_channel( cfg_t *cfg ){
 	int i;
 	const char *channel_name;
 
-	output_channel_conf_t out = CONF_OUTPUT_CHANNEL_FILE; //default is to output to file
+	output_channel_conf_t out = CONF_OUTPUT_CHANNEL_NONE;
 
 	for( i=0; i<nb_output_channel; i++) {
 		channel_name = cfg_getnstr(cfg, "output-channel", i);
@@ -570,6 +570,9 @@ static inline  output_channel_conf_t _parse_output_channel( cfg_t *cfg ){
 		else
 			log_write( LOG_WARNING, "Unexpected channel '%s'", channel_name );
 	}
+	//default is to output to file
+	if( out == CONF_OUTPUT_CHANNEL_NONE )
+		return CONF_OUTPUT_CHANNEL_FILE;
 	return out;
 }
 

--- a/src/configure.h
+++ b/src/configure.h
@@ -173,6 +173,9 @@ typedef struct reconstruct_data_conf_struct{
 typedef struct dpi_protocol_attribute_struct{
 	char* proto_name;
 	char* attribute_name;
+	uint16_t proto_id;  //protocol id: being interpreted when registering
+	uint16_t attribute_id; //attribute_id: being interpreted when registering
+	uint16_t proto_index; //indicating `th` order of the protocol when there exist duplicated ones in the hierarchy
 }dpi_protocol_attribute_t;
 
 

--- a/src/lib/log.h
+++ b/src/lib/log.h
@@ -64,8 +64,8 @@ static inline void log_close(){
  */
 #define ABORT( format, ... )                                                \
 	do{                                                                     \
-		log_write( LOG_ERR, format,## __VA_ARGS__ );                        \
-		fprintf( stderr, format"\n",## __VA_ARGS__ );                       \
+		log_write( LOG_ERR, format". Aborted",## __VA_ARGS__ );                        \
+		fprintf( stderr, format". Aborted\n",## __VA_ARGS__ );                       \
 		abort();                                                            \
 	}while( 0 )
 
@@ -74,7 +74,7 @@ static inline void log_close(){
  */
 #define ASSERT( exp, format, ... )                                                   \
 	while( !(exp) ){                                                                 \
-		log_write( LOG_ERR, "[%s:%d] "format,__FUNCTION__, __LINE__,## __VA_ARGS__ );\
+		log_write( LOG_ERR, "[%s:%d] "format". Aborted",__FUNCTION__, __LINE__,## __VA_ARGS__ );\
 		abort();                                                                     \
 	}
 

--- a/src/modules/dpi/dpi.c
+++ b/src/modules/dpi/dpi.c
@@ -111,16 +111,15 @@ static int _packet_handler(const ipacket_t * ipacket, void * user_args) {
 		if( session == NULL )
 			session = _create_session (ipacket, context);
 
-		IF_ENABLE_PCAP_DUMP(
-			if( context->pcap_dump )
-				pcap_dump_callback_on_receiving_packet( ipacket, context->pcap_dump );
-		)
-
 		IF_ENABLE_STAT_REPORT(
 			if( context->probe_config->reports.session->is_enable )
 				session_report_callback_on_receiving_packet( ipacket, session->session_stat, context);
 		)
 	}
+	IF_ENABLE_PCAP_DUMP(
+		if( context->pcap_dump )
+			pcap_dump_callback_on_receiving_packet( ipacket, context->pcap_dump );
+	)
 	return 0;
 }
 

--- a/src/modules/dpi/dpi.c
+++ b/src/modules/dpi/dpi.c
@@ -120,6 +120,10 @@ static int _packet_handler(const ipacket_t * ipacket, void * user_args) {
 		if( context->pcap_dump )
 			pcap_dump_callback_on_receiving_packet( ipacket, context->pcap_dump );
 	)
+
+	IF_ENABLE_STAT_REPORT(
+		event_based_report_callback_on_receiving_packet( ipacket, context->event_reports );
+	)
 	return 0;
 }
 

--- a/src/modules/dpi/report/event_based_report.c
+++ b/src/modules/dpi/report/event_based_report.c
@@ -62,9 +62,11 @@ static inline bool _is_string( int data_type ){
 	case MMT_STRING_DATA:
 	case MMT_STRING_LONG_DATA:
 	case MMT_GENERIC_HEADER_LINE:
+#ifdef MMT_U32_ARRAY
 	//surround the elements of an array by " and "
 	case MMT_U32_ARRAY:
 	case MMT_U64_ARRAY:
+#endif
 		return true;
 	}
 	return false;

--- a/src/modules/dpi/report/event_based_report.h
+++ b/src/modules/dpi/report/event_based_report.h
@@ -27,4 +27,11 @@ list_event_based_report_context_t* event_based_report_register( mmt_handler_t *d
  */
 void event_based_report_unregister( mmt_handler_t *dpi_handler, list_event_based_report_context_t *context  );
 
+
+/**
+ * This function needs to be called on each packet once it is classified
+ * @param context
+ * @param packet
+ */
+void event_based_report_callback_on_receiving_packet( const ipacket_t *packet, list_event_based_report_context_t *context);
 #endif /* SRC_MODULES_DPI_REPORT_EVENT_BASED_REPORT_H_ */


### PR DESCRIPTION
## v1.5.1
- 24 Feb 2022
- Support `proto.index.att` syntax in `event-report`
- Add `delta-cond` in `event-report` to issue an report only if there is a change in a set of attributes
- Improve `event-report` trigger mechanisme to be called only one when the whole packet is classified
- Fixed bug when `output-channel` always containt `file-output`
- Fixed bug that does not dump no-session packets to pcap files
- Add all options/component when being packaged in a container
- Add `. Aborted` word when explicitly aborting the current execution