### PR TITLE
Fix the error: undefined reference to `mmt_alloc_and_init_zero' when …

### DIFF
--- a/src/modules/dpi/reassembly/tcp_reassembly.c
+++ b/src/modules/dpi/reassembly/tcp_reassembly.c
@@ -8,6 +8,7 @@
 #include <tcpip/mmt_tcpip.h>
 
 #include "../../../lib/memory.h"
+#include "../../../lib/malloc.h"
 
 struct tcp_reassembly_struct{
 	tcp_session_payload_callback_t callback;


### PR DESCRIPTION
Compile mmt-probe:
```sh
 make compile TCP_REASSEMBLY_MODULE
```

Error log:
```sh
/usr/bin/ld: /home/montimage/workspace/mmt-probe/src/modules/dpi/reassembly/tcp_reassembly.o: in function `tcp_reassembly_alloc_init':
tcp_reassembly.c:(.text+0x3c): undefined reference to `mmt_alloc_and_init_zero'
/usr/bin/ld: /home/montimage/workspace/mmt-probe/src/modules/dpi/reassembly/tcp_reassembly.o: in function `tcp_reassembly_close':
tcp_reassembly.c:(.text+0x64): undefined reference to `mmt_probe_free'
collect2: error: ld returned 1 exit status
make: *** [mk/compile-pcap.mk:9: compile] Error 1
```

Problem: missing reference to `malloc.h` in `tcp_reassembly.c` file.