### PR TITLE
Output to mqtt

### DIFF
--- a/.github/workflows/build-from-source.yml
+++ b/.github/workflows/build-from-source.yml
@@ -2,7 +2,7 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, output-to-mqtt ]
   pull_request:
     branches: [ master ]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.6.0 (16 May 2025)
+- add ability to output reports to MQTT: `mqtt-output`
+- add `pcap-filter` parameter to capture only selected packets using BPF syntax
+- fixed reports' issue when analysing IP-in-IP
+
 ## v1.5.12
 - fixed bug rejecting -X param having same value
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ APP = probe
 
 #get git version abbrev
 GIT_VERSION := $(shell git log --format="%h" -n 1)
-VERSION     := 1.5.12
+VERSION     := 1.6.0
 
 ifndef TOP_DIR
   #current directory

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -116,9 +116,9 @@ make DPDK_CAPTURE compile
 make compile
 ```
 
-##### **Output modules**:  `REDIS_MODULE`, `KAFKA_MODULE`, `MONGODB_MODULE`
+##### **Output modules**:  `REDIS_MODULE`, `KAFKA_MODULE`, `MQTT_MODULE`, `MONGODB_MODULE`
 
-In addition to output reports to files, MMT-Probe can ouput to redis, kafka and mongodb servers. 
+In addition to output reports to files, MMT-Probe can ouput to redis, kafka, mqtt, and mongodb servers. 
 
 Install required libraries
 
@@ -146,6 +146,11 @@ sudo make install
 sudo ldconfig
 ```
 
+- When output to mqtt, we need [Eclipse Paho MQTT C library](https://github.com/eclipse-paho/paho.mqtt.c).
+
+```bash
+sudo apt install libpaho-mqtt-dev
+```
 
 - When output to mongodb, we need [`libmongo` and `libbson`](http://mongoc.org/libmongoc/current/installing.html)
 
@@ -162,7 +167,9 @@ sudo make install
 Compile MMT-Probe:
 
 ```bash
-#support output to file, redis and kafka servers
+# support output to file and MQTT servers
+make MQTT_MODULE compile
+#or support output to file, redis and kafka servers
 make REDIS_MODULE KAFKA_MODULE compile
 #or support only output to file and mongodb server
 make MONGODB_MODULE compile

--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -160,6 +160,17 @@ ifdef REDIS_MODULE
   MODULE_SRCS  += $(wildcard $(SRC_DIR)/modules/output/redis/*.c)
 endif
 
+$(eval $(call check_module,MQTT_MODULE))
+ifdef MQTT_MODULE
+  ifdef STATIC_LINK
+    MODULE_LIBS  += -l:lpaho-mqtt3c.a
+  else
+    MODULE_LIBS  += -lpaho-mqtt3c
+  endif
+  MODULE_FLAGS += -DMQTT_MODULE
+  MODULE_SRCS  += $(wildcard $(SRC_DIR)/modules/output/mqtt/*.c)
+endif
+
 $(eval $(call check_module,SOCKET_MODULE))
 ifdef SOCKET_MODULE
   MODULE_FLAGS += -DSOCKET_MODULE

--- a/mmt-probe.conf
+++ b/mmt-probe.conf
@@ -107,6 +107,18 @@ kafka-output {
     topic = "report"       #name of topic to which the message will be published
 }
 
+mqtt-output {
+    enable = false
+    address = "tcp://localhost:1883" # server URI in format protocol://host:port
+                     # currently, protocol must be
+                     #  tcp:// or mqtt:// - Insecure TCP
+                     #  ssl:// or mqtts:// - Encrypted SSL/TLS
+                     #  ws:// - Insecure websockets
+                     #  wss:// - Secure web sockets
+    topic = "report" # 	The topic associated with published message.
+    retain = false  # whether MQTT server should retain a copy of the message.
+}
+
 # indicates mongodb output:
 mongodb-output {
     enable = false
@@ -177,7 +189,7 @@ security {
             # Note: if we have thread-nb = 2 and "(1:1)(2:3)", then only rules 1 and 3 are verified (the others are not)
 
     output-channel = {} # Reports are sent to the output channels . The default value is a file .
-            # More than one output channel is possible . In this case , the value should be a set of comma - separated values ; for example: { redis , kafka , file, mongodb, socket }.
+            # More than one output channel is possible . In this case , the value should be a set of comma - separated values ; for example: { redis , kafka , file, mongodb, socket, mqtt }.
             # Reports are sent to output channels only when the global parameters are enable ( file-output.enable = true ,redis-output.enable = true , kafka-output.enable = true, mongodb-output.enable = true)
 
     report-rule-description = true # true to include rule's description into the alert reports,

--- a/mmt-probe.conf
+++ b/mmt-probe.conf
@@ -55,6 +55,13 @@ input {
 
     # option only for DPDK capture
     dpdk-option = "--syslog=syslog --log-level=5 -c 0x55555555555"
+    
+    # option only for PCAP capture
+    pcap-filter = "" # Apply filter using Berkeley Packet Filter. Example:  
+                     #   "tcp port 80" — TCP traffic on port 80
+                     #   "udp port 53" — DNS queries
+                     #   "host 192.168.1.1" — All traffic to/from a host
+                     #   "src net 192.168.0.0/16" — Packets from a subnet
 }
 
 # Each kind of report can output to different channel, such as, file, kafak, ...

--- a/script/install-from-source.sh
+++ b/script/install-from-source.sh
@@ -58,6 +58,9 @@ make -j $CPU
 make install
 ldconfig
 
+# install MQTT library
+sudo apt install libpaho-mqtt-dev
+
 
 # install mmt-dpi
 cd $TMP_DIR
@@ -84,7 +87,7 @@ make deb
 cd $TMP_DIR
 git clone https://github.com/montimage/mmt-probe mmt-probe
 cd mmt-probe
-MODULES="KAFKA_MODULE MONGODB_MODULE PCAP_DUMP_MODULE QOS_MODULE REDIS_MODULE SECURITY_MODULE SOCKET_MODULE LTE_MODULE"
+MODULES="KAFKA_MODULE MONGODB_MODULE PCAP_DUMP_MODULE QOS_MODULE REDIS_MODULE MQTT_MODULE SECURITY_MODULE SOCKET_MODULE LTE_MODULE"
 make -j $CPU $MODULES compile
 make $MODULES deb
 make $MODULES install

--- a/script/install-from-source.sh
+++ b/script/install-from-source.sh
@@ -8,6 +8,9 @@ fi
 # exit immediately when having error
 set -e
 
+# directory of this script
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 # the temp directory to contain sources to be installed
 TMP_DIR=$(mktemp -d -t mmt-probe-installation-XXXXXXXXXX)
 # do not forget to remove the temp dir when exit
@@ -84,9 +87,9 @@ make deb
 
 
 # install mmt-probe
-cd $TMP_DIR
-git clone https://github.com/montimage/mmt-probe mmt-probe
-cd mmt-probe
+cd "$SCRIPT_DIR/.."
+#git clone https://github.com/montimage/mmt-probe mmt-probe
+#cd mmt-probe
 MODULES="KAFKA_MODULE MONGODB_MODULE PCAP_DUMP_MODULE QOS_MODULE REDIS_MODULE MQTT_MODULE SECURITY_MODULE SOCKET_MODULE LTE_MODULE"
 make -j $CPU $MODULES compile
 make $MODULES deb

--- a/src/configure.c
+++ b/src/configure.c
@@ -179,6 +179,14 @@ static inline cfg_t *_load_cfg_from_file(const char *filename) {
 			CFG_END()
 	};
 
+	cfg_opt_t mqtt_output_opts[] = {
+			CFG_STR("address", "tcp://localhost:1883", CFGF_NONE),
+			CFG_STR("topic", "report", CFGF_NONE),
+			CFG_BOOL("enable", false, CFGF_NONE),
+			CFG_BOOL("retain", false, CFGF_NONE),
+			CFG_END()
+	};
+
 	cfg_opt_t mongodb_output_opts[] = {
 			CFG_STR("hostname", "localhost", CFGF_NONE),
 			CFG_INT("port", 27017, CFGF_NONE),
@@ -320,6 +328,7 @@ static inline cfg_t *_load_cfg_from_file(const char *filename) {
 			CFG_SEC("file-output", file_output_opts, CFGF_NONE),
 			CFG_SEC("redis-output", redis_output_opts, CFGF_NONE),
 			CFG_SEC("kafka-output", kafka_output_opts, CFGF_NONE),
+			CFG_SEC("mqtt-output", mqtt_output_opts, CFGF_NONE),
 			CFG_SEC("data-output", data_output_opts, CFGF_NONE),
 			CFG_SEC("socket-output", socket_opts, CFGF_NONE),
 
@@ -511,6 +520,19 @@ static inline kafka_output_conf_t *_parse_output_to_kafka( cfg_t *cfg ){
 	return ret;
 }
 
+static inline mqtt_output_conf_t *_parse_output_to_mqtt( cfg_t *cfg ){
+	if( (cfg = _get_first_cfg_block( cfg, "mqtt-output")) == NULL )
+		return NULL;
+
+	mqtt_output_conf_t *ret = mmt_alloc( sizeof( mqtt_output_conf_t ));
+
+	ret->is_enable   = cfg_getbool( cfg, "enable");
+	ret->is_retain   = cfg_getbool( cfg, "retain");
+	ret->address     = _cfg_get_str(cfg, "address");
+	ret->topic_name  = _cfg_get_str(cfg, "topic");
+
+	return ret;
+}
 static inline mongodb_output_conf_t *_parse_output_to_mongodb( cfg_t *cfg ){
 	if( (cfg = _get_first_cfg_block( cfg, "mongodb-output")) == NULL )
 		return NULL;
@@ -599,6 +621,8 @@ static inline  output_channel_conf_t _parse_output_channel( cfg_t *cfg ){
 			out |= CONF_OUTPUT_CHANNEL_SOCKET;
 		else if( strncmp( channel_name, "stdout", 6 ) == 0 )
 			out |= CONF_OUTPUT_CHANNEL_STDOUT;
+		else if( strncmp( channel_name, "mqtt", 4 ) == 0 )
+			out |= CONF_OUTPUT_CHANNEL_MQTT;
 		else
 			log_write( LOG_WARNING, "Unexpected channel '%s'", channel_name );
 	}
@@ -1177,8 +1201,9 @@ probe_conf_t* conf_load_from_file( const char* filename ){
 	_parse_output_block( &conf->outputs, cfg );
 	//set of output channels
 	conf->outputs.file  = _parse_output_to_file( cfg );
-	conf->outputs.kafka = _parse_output_to_kafka( cfg );
 	conf->outputs.redis = _parse_output_to_redis( cfg );
+	conf->outputs.kafka = _parse_output_to_kafka( cfg );
+	conf->outputs.mqtt  = _parse_output_to_mqtt( cfg );
 	conf->outputs.mongodb = _parse_output_to_mongodb( cfg );
 	conf->outputs.socket = _parse_socket_block( cfg );
 	//a global
@@ -1346,6 +1371,11 @@ void conf_release( probe_conf_t *conf){
 		mmt_probe_free( conf->outputs.redis->host.host_name );
 		mmt_probe_free( conf->outputs.redis->channel_name );
 		mmt_probe_free( conf->outputs.redis );
+	}
+	if( conf->outputs.mqtt ){
+		mmt_probe_free( conf->outputs.mqtt->address );
+		mmt_probe_free( conf->outputs.mqtt->topic_name );
+		mmt_probe_free( conf->outputs.mqtt );
 	}
 	if( conf->outputs.mongodb ){
 		mmt_probe_free( conf->outputs.mongodb->collection_name );

--- a/src/configure.c
+++ b/src/configure.c
@@ -309,6 +309,7 @@ static inline cfg_t *_load_cfg_from_file(const char *filename) {
 			CFG_INT("buffer-size", 0, CFGF_NONE),
 			CFG_INT("timeout", 0, CFGF_NONE),
 			CFG_STR("dpdk-option", "", CFGF_NONE ),
+			CFG_STR("pcap-filter", "", CFGF_NONE ),
 			CFG_END()
 	};
 
@@ -460,7 +461,7 @@ static inline input_source_conf_t * _parse_input_source( cfg_t *cfg ){
 	ret->snap_len    = cfg_getint( cfg, "snap-len" );
 	ret->buffer_size = cfg_getint( cfg, "buffer-size" );
 	ret->timeout     = cfg_getint( cfg, "timeout" );
-
+	ret->pcap_filter = _cfg_get_str(cfg, "pcap-filter");
 	return ret;
 }
 
@@ -1308,6 +1309,7 @@ void conf_release( probe_conf_t *conf){
 	int i;
 
 	mmt_probe_free( conf->input->input_source );
+	mmt_probe_free( conf->input->pcap_filter );
 	mmt_probe_free( conf->input );
 
 	for( i=0; i<conf->reports.events_size; i++ )

--- a/src/configure.h
+++ b/src/configure.h
@@ -53,6 +53,14 @@ typedef struct kafka_output_conf_struct{
 	char *topic_name;
 }kafka_output_conf_t;
 
+typedef struct mqtt_output_conf_struct{
+	bool is_enable;
+	char* address;
+	//further setting for mqtt published message
+	char *topic_name;
+	bool is_retain;
+}mqtt_output_conf_t;
+
 typedef struct mongodb_output_conf_struct{
 	bool is_enable;
 	internet_service_address_t host;
@@ -85,9 +93,11 @@ typedef enum {
 	CONF_OUTPUT_CHANNEL_MONGODB = 8,
 	CONF_OUTPUT_CHANNEL_SOCKET  = 16,
 	CONF_OUTPUT_CHANNEL_STDOUT  = 32,
+	CONF_OUTPUT_CHANNEL_MQTT    = 64,
 	CONF_OUTPUT_CHANNEL_ALL     = CONF_OUTPUT_CHANNEL_FILE  | CONF_OUTPUT_CHANNEL_REDIS
 								| CONF_OUTPUT_CHANNEL_KAFKA | CONF_OUTPUT_CHANNEL_MONGODB
 								| CONF_OUTPUT_CHANNEL_SOCKET| CONF_OUTPUT_CHANNEL_STDOUT
+								| CONF_OUTPUT_CHANNEL_MQTT
 }output_channel_conf_t;
 
 #define IS_ENABLE_OUTPUT_TO( name, channels ) ( channels & CONF_OUTPUT_CHANNEL_ ##name )
@@ -265,6 +275,7 @@ typedef struct output_conf_struct{
 	file_output_conf_t  *file;
 	redis_output_conf_t *redis;
 	kafka_output_conf_t *kafka;
+	mqtt_output_conf_t *mqtt;
 	mongodb_output_conf_t *mongodb;
 	socket_output_conf_t *socket;
 	enum {OUTPUT_FORMAT_CSV, OUTPUT_FORMAT_JSON} format;

--- a/src/configure.h
+++ b/src/configure.h
@@ -80,6 +80,7 @@ typedef struct input_source_conf_struct{
 	uint16_t snap_len;    //pcap param
 	uint32_t buffer_size; //pcap param
 	uint32_t timeout;     //pcap param
+	char *pcap_filter;    //https://www.tcpdump.org/manpages/pcap-filter.7.html
 
 	IF_ENABLE_DPDK( char *dpdk_options; )
 }input_source_conf_t;

--- a/src/configure_override.h
+++ b/src/configure_override.h
@@ -155,6 +155,7 @@ DECLARE_CONF_ATT(
 	//input
 	(CONF_ATT__INPUT__MODE,        "input.mode",        &conf->input->input_mode,   UINT16_T),
 	(CONF_ATT__INPUT__SOURCE,      "input.source",      &conf->input->input_source, CHAR_STAR),
+	(CONF_ATT__INPUT__PCAP_FILTER, "input.pcap-filter", &conf->input->pcap_filter,  CHAR_STAR),
 	(CONF_ATT__INPUT__SNAP_LEN,    "input.snap-len",    &conf->input->snap_len,     UINT16_T),
 	(CONF_ATT__INPUT__BUFFER_SIZE, "input.buffer-size", &conf->input->buffer_size,  UINT32_T),
 	(CONF_ATT__INPUT__TIMEOUT,     "input.timeout",     &conf->input->timeout,      UINT32_T),

--- a/src/configure_override.h
+++ b/src/configure_override.h
@@ -21,6 +21,7 @@
 #define SOCKET_MODULE
 #define LICENSE_CHECK
 #define DPDK_MODULE
+#define MQTT_MODULE
 #endif
 
 /**
@@ -198,6 +199,14 @@ DECLARE_CONF_ATT(
 	(CONF_ATT__REDIS_OUTPUT__HOSTNAME,     "redis-output.hostname", &conf->outputs.redis->host.host_name,   CHAR_STAR),
 	(CONF_ATT__REDIS_OUTPUT__CHANNEL_NAME, "redis-output.channel",  &conf->outputs.redis->channel_name,     CHAR_STAR),
 	(CONF_ATT__REDIS_OUTPUT__PORT,         "redis-output.port",     &conf->outputs.redis->host.port_number, UINT16_T),
+#endif
+
+#ifdef MQTT_MODULE
+	//mqtt-output
+	(CONF_ATT__MQTT_OUTPUT__ENABLE,       "mqtt-output.enable",   &conf->outputs.mqtt->is_enable,        BOOL),
+	(CONF_ATT__MQTT_OUTPUT__HOSTNAME,     "mqtt-output.address",  &conf->outputs.mqtt->address,          CHAR_STAR),
+	(CONF_ATT__MQTT_OUTPUT__CHANNEL_NAME, "mqtt-output.topic",    &conf->outputs.mqtt->topic_name,       CHAR_STAR),
+	(CONF_ATT__MQTT_OUTPUT__PORT,         "mqtt-output.retain",   &conf->outputs.mqtt->is_retain,        BOOL),
 #endif
 
 #ifdef SOCKET_MODULE

--- a/src/context.h
+++ b/src/context.h
@@ -70,7 +70,7 @@ typedef struct probe_context_struct{
  */
 static inline void context_print_traffic_stat( const probe_context_t *context, const struct timeval *now ){
 	//print a dummy message to inform that MMT-Probe is still alive
-	char message[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 	int valid = 0;
 
 	//build message

--- a/src/lib/limit.h
+++ b/src/lib/limit.h
@@ -99,6 +99,11 @@
 	#define IF_ENABLE_SOCKET( x )
 #endif
 
+#ifdef MQTT_MODULE
+	#define IF_ENABLE_MQTT( x ) x
+#else
+	#define IF_ENABLE_MQTT( x )
+#endif
 
 #ifdef PCAP_DUMP_MODULE
 	#define IF_ENABLE_PCAP_DUMP( x ) x

--- a/src/modules/dpi/lte/lte_qos_report.c
+++ b/src/modules/dpi/lte/lte_qos_report.c
@@ -53,7 +53,7 @@ static void _got_data(const ipacket_t * ipacket, attribute_t * attribute, void *
 	//report if all elements have been fulfilled
 	if( context->qci != 0 && context->teid != 0 && context->ue_id != 0 ){
 		int valid = 0;
-		char message[ MAX_LENGTH_REPORT_MESSAGE ];
+		char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 		STRING_BUILDER_WITH_SEPARATOR( valid, message, MAX_LENGTH_REPORT_MESSAGE-valid, ",",
 				__INT( context->ue_id ),
 				__INT( context->teid  ),

--- a/src/modules/dpi/lte/topology_report.c
+++ b/src/modules/dpi/lte/topology_report.c
@@ -37,7 +37,7 @@ struct lte_topo_report_struct{
 
 static inline bool _build_msg_to_add_new_entity( char *message, const s1ap_entity_t *entity){
 	int valid = 0;
-	char message_tmp[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message_tmp[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 	char ip_str[INET_ADDRSTRLEN];
 
 	//empty ip
@@ -122,7 +122,7 @@ static void _got_s1ap_packet(const ipacket_t * ipacket, attribute_t * attribute,
 	if( attribute->data == NULL )
 		return;
 
-	char message[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 
 
 	const mmt_binary_var_data_t *binary_data = (mmt_binary_var_data_t *)attribute->data;

--- a/src/modules/dpi/pcap_dump/pcap_dump.c
+++ b/src/modules/dpi/pcap_dump/pcap_dump.c
@@ -260,7 +260,7 @@ pcap_dump_context_t* pcap_dump_start( uint16_t worker_index, const probe_conf_t 
 	pcap_dump_conf_t *config = probe_config->reports.pcap_dump;
 	if( ! config->is_enable )
 		return NULL;
-	char msg[MAX_LENGTH_REPORT_MESSAGE];
+	char msg[MAX_LENGTH_REPORT_MESSAGE + 1 ];
 	size_t index=0;
 
 	pcap_dump_context_t *context = mmt_alloc_and_init_zero(sizeof( pcap_dump_context_t ));

--- a/src/modules/dpi/reconstruct/http/http_reconstruct.c
+++ b/src/modules/dpi/reconstruct/http/http_reconstruct.c
@@ -418,7 +418,7 @@ void http_reconstruct_release( http_reconstruct_t *context){
  * @param session
  */
 void http_reconstruct_flush_session_to_file_and_free( http_session_t *session ){
-	char message[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 
 	if( session == NULL )
 		return;

--- a/src/modules/dpi/report/event_based_report.c
+++ b/src/modules/dpi/report/event_based_report.c
@@ -16,7 +16,7 @@ typedef struct event_based_report_context_struct {
 	/**
 	 * the latest values of the protocols and attributes to be checked in the delta condition above
 	 */
-	char last_delta_atts_values[MAX_LENGTH_REPORT_MESSAGE];
+	char last_delta_atts_values[MAX_LENGTH_REPORT_MESSAGE + 1 ];
 }event_based_report_context_t;
 
 
@@ -127,13 +127,13 @@ static void _event_report_handle( const ipacket_t *packet, attribute_t *attribut
 	event_based_report_context_t *context = (event_based_report_context_t *)arg;
 
 	size_t i;
-	char message[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 	int offset, ret;
 	const event_report_conf_t *config = context->config;
 
 	//if delta-cond is available
 	if( config->delta_condition.attributes_size ){
-		memset( message, 0, MAX_LENGTH_REPORT_MESSAGE );
+		memset( message, 0, sizeof(message) );
 		ret = _get_attributes_values(packet,
 				config->delta_condition.attributes,
 				config->delta_condition.attributes_size,

--- a/src/modules/dpi/report/micro_flow_report.c
+++ b/src/modules/dpi/report/micro_flow_report.c
@@ -22,7 +22,7 @@ micro_flow_report_context_t *micro_flow_report_alloc_init( const micro_flow_conf
 }
 
 static inline void _print_micro_flow_report( micro_flow_stats_t *stat, output_t *output, output_channel_conf_t channel ){
-	char message[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 
 	//App id, Nb of flows, DL Packet Count, UL Packet Count, DL Byte Count, UL Byte Count
 	int offset = 0;

--- a/src/modules/dpi/report/no_session_report.c
+++ b/src/modules/dpi/report/no_session_report.c
@@ -70,7 +70,7 @@ static void _protocols_stats_iterator(uint32_t proto_id, void * args) {
 
 	//printf ("report_number = %lu \n", th->report_counter);
 	char proto_path_str[128];
-	char message[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 	int i, offset;
 	proto_hierarchy_t proto_hierarchy;
 	while (proto_stats != NULL) {
@@ -111,7 +111,7 @@ static inline void _report_ip_frag_stat( no_session_report_context_t *context ){
 	proto_statistics_t * proto_stats = get_protocol_stats( context->dpi_handler, PROTO_IP );
 
 	char proto_path_str[128];
-	char message[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 	int i, offset;
 	proto_hierarchy_t proto_hierarchy;
 	while( proto_stats != NULL ){

--- a/src/modules/dpi/report/query_based_report.c
+++ b/src/modules/dpi/report/query_based_report.c
@@ -174,7 +174,7 @@ static size_t _get_string_values( size_t message_size, char *message,
 
 static void _query_report_handle( const ipacket_t *packet,  query_based_report_context_t *context){
 	const query_report_conf_t *config = context->config;
-	char message[MAX_LENGTH_REPORT_MESSAGE], *key;
+	char message[MAX_LENGTH_REPORT_MESSAGE + 1 ], *key;
 	size_t key_len;
 	query_operator_stack_t **select_operators;
 
@@ -382,7 +382,7 @@ void query_based_report_unregister( mmt_handler_t *dpi_handler, list_query_based
 
 static void _flush_reports_then_reset( query_based_report_context_t *rep, const struct timeval *tv ){
 	const query_report_conf_t *config = rep->config;
-	char message[MAX_LENGTH_REPORT_MESSAGE], *p;
+	char message[MAX_LENGTH_REPORT_MESSAGE + 1 ], *p;
 	query_operator_stack_t **select_operators;
 	size_t i;
 	hash_item_t *it;

--- a/src/modules/dpi/report/radius_report.c
+++ b/src/modules/dpi/report/radius_report.c
@@ -34,7 +34,7 @@ static void _radius_code_handle(const ipacket_t *ipacket, attribute_t *attribute
 			return;
 
 	radius_report_context_t *context = (radius_report_context_t *) user_args;
-	char message[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 
 	char f_ipv4[INET_ADDRSTRLEN];
 	char sgsn_ip[INET_ADDRSTRLEN];

--- a/src/modules/dpi/report/session_report.c
+++ b/src/modules/dpi/report/session_report.c
@@ -59,8 +59,8 @@ static inline void _write_behaviour_report( file_output_t *output,
 #ifndef SIMPLE_REPORT
 //This callback is called by DPI periodically
 static inline void _print_ip_session_report (const mmt_session_t * dpi_session, session_stat_t * session_stat, const dpi_context_t *context){
-	uint64_t ul_packets = get_session_ul_cap_packet_count(dpi_session);
-	uint64_t dl_packets = get_session_dl_cap_packet_count(dpi_session);
+	uint64_t ul_packets = get_session_total_ul_packet_count(dpi_session);
+	uint64_t dl_packets = get_session_total_dl_packet_count(dpi_session);
 	uint64_t total_packets = ul_packets + dl_packets;
 
 	// check the condition if in the last interval there was a protocol activity or not
@@ -68,12 +68,12 @@ static inline void _print_ip_session_report (const mmt_session_t * dpi_session, 
 	if( total_packets == (session_stat->packets.upload + session_stat->packets.download) )
 		return;
 
-	uint64_t ul_volumes = get_session_ul_cap_byte_count(dpi_session);
-	uint64_t dl_volumes = get_session_dl_cap_byte_count(dpi_session);
+	uint64_t ul_volumes = get_session_total_ul_byte_count(dpi_session);
+	uint64_t dl_volumes = get_session_total_dl_byte_count(dpi_session);
 	uint64_t total_volumes = ul_volumes + dl_volumes;
 
-	uint64_t ul_payload = get_session_ul_data_byte_count(dpi_session);
-	uint64_t dl_payload = get_session_dl_data_byte_count(dpi_session);
+	uint64_t ul_payload = get_session_total_ul_data_byte_count(dpi_session);
+	uint64_t dl_payload = get_session_total_dl_data_byte_count(dpi_session);
 	uint64_t total_payload = ul_payload + dl_payload;
 
 	const proto_hierarchy_t * proto_hierarchy = get_session_protocol_hierarchy(dpi_session);
@@ -261,8 +261,8 @@ static inline void _print_ip_session_report (const mmt_session_t * dpi_session, 
 //This callback is called by DPI periodically
 static inline void _print_ip_session_report (const mmt_session_t * dpi_session, session_stat_t * session, const dpi_context_t *context){
 
-	uint64_t ul_volumes = get_session_ul_cap_byte_count(dpi_session);
-	uint64_t dl_volumes = get_session_dl_cap_byte_count(dpi_session);
+	uint64_t ul_volumes = get_session_total_ul_byte_count(dpi_session);
+	uint64_t dl_volumes = get_session_total_dl_byte_count(dpi_session);
 
 	if( unlikely( ul_volumes + dl_volumes == 0 ))
 		return;

--- a/src/modules/dpi/report/session_report.c
+++ b/src/modules/dpi/report/session_report.c
@@ -36,7 +36,7 @@ static inline void _write_behaviour_report( file_output_t *output,
 		uint64_t dl_volume
 		){
 
-	char message[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 	int valid = 0;
 	STRING_BUILDER_WITH_SEPARATOR( valid, message, MAX_LENGTH_REPORT_MESSAGE, ",",
 			__INT( BEHAVIOUR_REPORT_ID ),
@@ -128,7 +128,7 @@ static inline void _print_ip_session_report (const mmt_session_t * dpi_session, 
 
 	struct timeval start_time = get_session_init_time(dpi_session);
 
-	char message[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 	int valid = 0;
 	STRING_BUILDER_WITH_SEPARATOR( valid, message, MAX_LENGTH_REPORT_MESSAGE, ",",
 		__INT( context->stat_periods_index),
@@ -280,7 +280,7 @@ static inline void _print_ip_session_report (const mmt_session_t * dpi_session, 
 			proto_hierarchy,
 			app_path, sizeof( app_path) );
 
-	char message[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 	int valid = 0;
 	STRING_BUILDER_WITH_SEPARATOR( valid, message, MAX_LENGTH_REPORT_MESSAGE, ",",
 			__INT( context->stat_periods_index ),

--- a/src/modules/lpi/lpi.c
+++ b/src/modules/lpi/lpi.c
@@ -70,7 +70,7 @@ static void _report_one_item( size_t key_len, void *_key, void *_data, void *arg
 	inet_ntop4( key->ip_dst, ip_dst_str );
 	inet_ntop4( key->ip_src, ip_src_str );
 
-	char message[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 	uint32_t proto_id = PROTO_IP; //IPv4
 	int valid = 0;
 	STRING_BUILDER_WITH_SEPARATOR( valid, message, MAX_LENGTH_REPORT_MESSAGE, ",",

--- a/src/modules/output/mqtt/mqtt_output.c
+++ b/src/modules/output/mqtt/mqtt_output.c
@@ -1,0 +1,98 @@
+/*
+ * mqtt_output.c
+ *
+ *  Created on: May 7, 2025
+ *      Author: nhnghia
+ */
+
+#include <MQTTClient.h>
+#include "mqtt_output.h"
+#include "../../../lib/log.h"
+#include "../../../lib/malloc.h"
+
+struct mqtt_output_struct{
+	uint16_t probe_id;
+	const mqtt_output_conf_t *config;
+	MQTTClient client;
+};
+
+static void _connect_to_mqtt(mqtt_output_t *context) {
+	char client_id[100];
+	snprintf(client_id, sizeof(client_id), "mmt-probe-%d", context->probe_id);
+
+	MQTTClient_connectOptions conn_opts = MQTTClient_connectOptions_initializer;
+
+	conn_opts.keepAliveInterval = 20;
+	conn_opts.cleansession = 1;
+
+	int rc;
+
+	rc = MQTTClient_create(&context->client, context->config->address,
+			client_id, MQTTCLIENT_PERSISTENCE_NONE, NULL);
+
+	if( rc ){
+		log_write( LOG_ERR, "Failed to create MQTT client '%s: %d'", client_id, rc);
+		abort();
+	} else
+		log_write( LOG_INFO, "Created MQTT client '%s'", client_id);
+
+
+	rc = MQTTClient_connect(context->client, &conn_opts);
+	if( rc != MQTTCLIENT_SUCCESS ) {
+		log_write(LOG_ERR, "Failed to connect MQTT to '%s': %d", context->config->address, rc);
+		abort();
+	} else
+		log_write(LOG_INFO, "Connected MQTT to '%s'", context->config->address);
+}
+
+mqtt_output_t* mqtt_output_alloc_init( const mqtt_output_conf_t*config,  uint16_t probe_id ){
+	if( config->is_enable == false)
+		return NULL;
+	mqtt_output_t *ret = mmt_alloc_and_init_zero( sizeof( mqtt_output_t ));
+	ret->probe_id = probe_id;
+	ret->config = config;
+
+	//trigger the connection
+	_connect_to_mqtt( ret );
+
+	return ret;
+}
+
+int mqtt_output_send( mqtt_output_t *context, const char *message ){
+	MQTTClient_message pubmsg = MQTTClient_message_initializer;
+	MQTTClient_deliveryToken token;
+	int rc;
+
+	pubmsg.payload = (void *)message;
+	pubmsg.payloadlen = (int) strlen(message);
+	pubmsg.qos = 2; //Once and one only - the message will be delivered exactly once.
+	pubmsg.retained = context->config->is_retain;
+
+	rc = MQTTClient_publishMessage(context->client, context->config->topic_name, &pubmsg, &token);
+	if( rc != MQTTCLIENT_SUCCESS ){
+		log_write(LOG_ERR, "Failed to publish MQTT message to '%s': %d", context->config->topic_name, rc);
+		return 0;
+	}
+
+	const unsigned long timeout = 10*1000; //The maximum time to wait in milliseconds.
+	//wait for the message has been published
+	rc = MQTTClient_waitForCompletion(context->client, token, timeout);
+	return 1;
+}
+
+void mqtt_output_flush( mqtt_output_t * context){
+
+}
+
+void mqtt_output_release( mqtt_output_t * context){
+	if( context == NULL )
+		return;
+
+	int rc = MQTTClient_disconnect(context->client, 10000);
+
+	if( rc != MQTTCLIENT_SUCCESS)
+		log_write(LOG_ERR, "Failed to disconnect MQTT client: %d", rc);
+
+	MQTTClient_destroy(&context->client);
+	mmt_probe_free( context );
+}

--- a/src/modules/output/mqtt/mqtt_output.h
+++ b/src/modules/output/mqtt/mqtt_output.h
@@ -1,0 +1,23 @@
+/*
+ * mqtt_output.h
+ *
+ *  Created on: May 7, 2025
+ *      Author: nhnghia
+ */
+
+#ifndef SRC_MODULES_OUTPUT_MQTT_MQTT_OUTPUT_H_
+#define SRC_MODULES_OUTPUT_MQTT_MQTT_OUTPUT_H_
+
+#include "../../../configure.h"
+
+typedef struct mqtt_output_struct mqtt_output_t;
+
+mqtt_output_t* mqtt_output_alloc_init( const mqtt_output_conf_t*config,  uint16_t probe_id );
+
+int mqtt_output_send( mqtt_output_t * output, const char *message );
+
+void mqtt_output_flush( mqtt_output_t * output);
+
+void mqtt_output_release( mqtt_output_t * output);
+
+#endif /* SRC_MODULES_OUTPUT_MQTT_MQTT_OUTPUT_H_ */

--- a/src/modules/output/output.c
+++ b/src/modules/output/output.c
@@ -104,7 +104,7 @@ output_t *output_alloc_init( uint16_t output_id, const struct output_conf_struct
  */
 static inline int _write( output_t *output, output_channel_conf_t channels, const char *message, bool raw ){
 	int ret = 0;
-	char new_msg[ MAX_LENGTH_REPORT_MESSAGE ];
+	char new_msg[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 
 	//we surround message inside [] to convert it to JSON
 	//this needs to be done when:
@@ -210,7 +210,7 @@ int output_write_report( output_t *output, output_channel_conf_t channels,
 		return 0;
 	}
 
-	char message[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 	int offset = 0;
 	STRING_BUILDER_WITH_SEPARATOR( offset, message, MAX_LENGTH_REPORT_MESSAGE, ",",
 			__INT( report_type ),
@@ -254,7 +254,7 @@ int output_write_report_with_format( output_t *output, output_channel_conf_t cha
 	//otherwise there will be a deadlock as there will be a lock in @output_write_report
 	__UNLOCK_IF_NEED( output );
 
-	char message[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 	int offset, ret;
 
 	if( unlikely( format == NULL )){

--- a/src/modules/output/socket/socket_output.c
+++ b/src/modules/output/socket/socket_output.c
@@ -112,7 +112,7 @@ socket_output_t* socket_output_init( const socket_output_conf_t *config ){
 }
 
 bool socket_output_send( socket_output_t *context, const char *msg ){
-	char m[MAX_LENGTH_REPORT_MESSAGE];
+	char m[MAX_LENGTH_REPORT_MESSAGE + 1 ];
 	size_t len = snprintf(m, MAX_LENGTH_REPORT_MESSAGE, "%s\n", msg);
 	bool ret = false;
 	if( context->unix_socket_fd != NO_SOCKET_FD ){

--- a/src/modules/packet_capture/pcap/pcap_capture.c
+++ b/src/modules/packet_capture/pcap/pcap_capture.c
@@ -486,6 +486,20 @@ void pcap_capture_start( probe_context_t *context ){
 					context->config->stack_type);
 	}
 
+	// Compile and set the filter
+	struct bpf_program fp;
+	const char *pcap_filter = context->config->input->pcap_filter;
+	if( pcap_filter && strlen(pcap_filter) > 0 ){
+		log_write( LOG_INFO, "Applying filter: %s", pcap_filter );
+		ret = pcap_compile(pcap, &fp, pcap_filter, 0, PCAP_NETMASK_UNKNOWN);
+		ASSERT( ret == 0,
+			"Couldn't parse filter '%s': %s", pcap_filter, pcap_geterr(pcap));
+
+		ret = pcap_setfilter(pcap, &fp);
+		ASSERT( ret == 0,
+			"Couldn't install filter '%s': %s\n", pcap_filter, pcap_geterr(pcap));
+	}
+
 	context->modules.pcap->handler = pcap;
 
 	ret = 0;

--- a/src/modules/routine/system_stats.c
+++ b/src/modules/routine/system_stats.c
@@ -87,7 +87,7 @@ static void * _stats_routine(void * args){
 	//int freq = *((int*) f);
 
 	struct timeval ts;
-	char message[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 	int offset;
 
 	//disable? no output?

--- a/src/modules/security/security.c
+++ b/src/modules/security/security.c
@@ -273,7 +273,7 @@ static void _print_security_verdict(
 	struct timeval ts;
 	mmt_sec_decode_timeval(timestamp, &ts );
 
-	char message[ MAX_LENGTH_REPORT_MESSAGE ];
+	char message[ MAX_LENGTH_REPORT_MESSAGE + 1 ];
 	int offset = 0;
 	STRING_BUILDER_WITH_SEPARATOR( offset, message, sizeof( message ), ",",
 			__INT( rule->id ),


### PR DESCRIPTION
## v1.6.0 (16 May 2025)
- add ability to output reports to MQTT: `mqtt-output`
- add `pcap-filter` parameter to capture only selected packets using BPF syntax
- fixed reports' issue when analysing IP-in-IP
