### PR TITLE
feat: add Claude Code skills for MMT-Probe

### DIFF
--- a/agents-instructions.md
+++ b/agents-instructions.md
@@ -1,0 +1,594 @@
+# AI Agent Setup Instructions for MMT-Probe
+
+## Overview
+
+MMT-Probe is a C-based network traffic analysis probe developed by [Montimage](https://www.montimage.com). It performs deep packet inspection (DPI), security analysis, and protocol reconstruction on live or offline network traffic. This document provides step-by-step instructions for an AI agent to perform a complete from-scratch installation and setup.
+
+**Repository**: <https://github.com/montimage/mmt-probe>
+**Version**: 1.6.0
+**License**: Apache License 2.0
+
+---
+
+## Prerequisites
+
+### Required Software
+
+| Software         | Minimum Version | Purpose                           |
+|------------------|-----------------|-----------------------------------|
+| GCC              | 4.9+            | C compiler                        |
+| G++              | 4.9+            | C++ compiler (static linking)     |
+| GNU Make         | 3.81+           | Build system                      |
+| Git              | 2.0+            | Source code management             |
+| libconfuse       | any             | Configuration file parsing         |
+| libpcap          | any             | Packet capture (default backend)   |
+| MMT-DPI          | 1.7.1+          | Deep Packet Inspection library     |
+
+### Optional Software (per module)
+
+| Software         | Required By           | Purpose                     |
+|------------------|-----------------------|-----------------------------|
+| hiredis v1.0.2   | `REDIS_MODULE`        | Redis client library        |
+| librdkafka v1.8.2| `KAFKA_MODULE`        | Kafka client library        |
+| mongo-c-driver 1.9.5 | `MONGODB_MODULE` | MongoDB client library      |
+| libpaho-mqtt     | `MQTT_MODULE`         | MQTT client library         |
+| MMT-Security     | `SECURITY_MODULE`     | Security rule verification  |
+| libxml2          | `SECURITY_MODULE`     | XML parsing                 |
+| DPDK             | `DPDK_CAPTURE`        | High-performance packet I/O |
+| sysrepo/netopeer2| `NETCONF_MODULE`      | NETCONF protocol support    |
+| gperf            | `gperf` target        | Perfect hash generation     |
+
+### System Requirements
+
+- **OS**: Linux (Ubuntu 22.04 recommended; Debian, CentOS, Fedora supported)
+- **Architecture**: x86_64
+- **Privileges**: Root or `CAP_NET_RAW` for packet capture
+- **RAM**: Minimum 100 MB; 2 GB+ for DPDK mode (hugepages)
+- **Disk**: ~50 MB for installation + space for reports
+
+---
+
+## Setup Sequence
+
+### 1. System Package Installation
+
+#### Auto-detect OS
+
+```bash
+# Detect distribution
+OS_ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
+OS_VERSION=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"')
+echo "Detected OS: $OS_ID $OS_VERSION"
+```
+
+#### Install base packages
+
+**Debian/Ubuntu:**
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential gcc g++ cpp cmake git curl
+sudo apt-get install -y libconfuse-dev libpcap-dev
+```
+
+**RHEL/CentOS/Fedora:**
+
+```bash
+sudo yum groupinstall -y "Development Tools"
+sudo yum install -y cmake git curl
+sudo yum install -y libconfuse-devel libpcap-devel
+```
+
+#### Verification
+
+```bash
+gcc --version   # Must be >= 4.9
+g++ --version   # Must be >= 4.9
+make --version  # Must be >= 3.81
+git --version
+pkg-config --modversion libconfuse 2>/dev/null || dpkg -s libconfuse-dev 2>/dev/null | grep Version
+```
+
+---
+
+### 2. Install MMT-DPI (Required Dependency)
+
+MMT-DPI is the core deep packet inspection library. It **must** be installed before MMT-Probe.
+
+```bash
+# Create a temporary build directory
+TMP_DIR=$(mktemp -d -t mmt-setup-XXXXXXXXXX)
+cd "$TMP_DIR"
+
+# Clone and build MMT-DPI
+git clone https://github.com/montimage/mmt-dpi.git mmt-dpi
+cd mmt-dpi/sdk
+make -j$(nproc)
+sudo make install
+sudo ldconfig
+```
+
+#### Verification
+
+```bash
+ls /opt/mmt/dpi/lib/libmmt_core.so   # Should exist
+ls /opt/mmt/dpi/include/              # Should contain header files
+```
+
+---
+
+### 3. Install Optional Output Module Dependencies
+
+Install only the libraries needed for desired output modules. Skip any module you do not need.
+
+#### 3a. Redis Output (`REDIS_MODULE`)
+
+```bash
+cd "$TMP_DIR"
+git clone https://github.com/redis/hiredis.git hiredis
+cd hiredis
+git checkout v1.0.2
+make -j$(nproc)
+sudo make install
+sudo ldconfig
+```
+
+**Verification**: `ls /usr/local/lib/libhiredis.*`
+
+#### 3b. Kafka Output (`KAFKA_MODULE`)
+
+```bash
+sudo apt-get install -y libsasl2-dev libssl-dev   # Debian/Ubuntu
+# sudo yum install -y cyrus-sasl-devel openssl-devel  # RHEL/CentOS
+
+cd "$TMP_DIR"
+git clone https://github.com/edenhill/librdkafka.git librdkafka
+cd librdkafka
+git checkout v1.8.2
+./configure
+make -j$(nproc)
+sudo make install
+sudo ldconfig
+```
+
+**Verification**: `ls /usr/local/lib/librdkafka.*`
+
+#### 3c. MongoDB Output (`MONGODB_MODULE`)
+
+```bash
+sudo apt-get install -y pkg-config libssl-dev libsasl2-dev   # Debian/Ubuntu
+
+cd "$TMP_DIR"
+curl -Lk --output mongo-c.tar.gz https://github.com/mongodb/mongo-c-driver/releases/download/1.9.5/mongo-c-driver-1.9.5.tar.gz
+tar xzf mongo-c.tar.gz
+cd mongo-c-driver-1.9.5
+./configure --disable-automatic-init-and-cleanup
+make -j$(nproc)
+sudo make install
+sudo ldconfig
+```
+
+**Verification**: `pkg-config --modversion libmongoc-1.0`
+
+#### 3d. MQTT Output (`MQTT_MODULE`)
+
+```bash
+sudo apt-get install -y libpaho-mqtt-dev   # Debian/Ubuntu
+```
+
+**Verification**: `dpkg -s libpaho-mqtt-dev 2>/dev/null | grep Status`
+
+#### 3e. MMT-Security (`SECURITY_MODULE`)
+
+```bash
+sudo apt-get install -y libxml2-dev libpcap-dev libconfuse-dev
+
+cd "$TMP_DIR"
+git clone https://github.com/Montimage/mmt-security.git mmt-security
+cd mmt-security
+make clean-all
+make -j1   # Must use single thread to handle header generation ordering
+sudo make install
+sudo ldconfig
+```
+
+**Verification**: `ls /opt/mmt/security/lib/libmmt_security2.*`
+
+---
+
+### 4. Compile MMT-Probe
+
+Navigate to the MMT-Probe source directory.
+
+```bash
+cd /path/to/mmt-probe   # Replace with actual path
+```
+
+#### 4a. Minimal Build (file output + PCAP capture only)
+
+```bash
+make clean
+make -j$(nproc) compile
+```
+
+#### 4b. Build with Selected Modules
+
+Specify modules as make targets. Combine any of:
+
+| Module Target            | Requires Library     |
+|--------------------------|----------------------|
+| `REDIS_MODULE`           | hiredis              |
+| `KAFKA_MODULE`           | librdkafka           |
+| `MONGODB_MODULE`         | mongo-c-driver       |
+| `MQTT_MODULE`            | libpaho-mqtt         |
+| `SECURITY_MODULE`        | MMT-Security         |
+| `PCAP_DUMP_MODULE`       | (none)               |
+| `QOS_MODULE`             | (none)               |
+| `SOCKET_MODULE`          | (none)               |
+| `LTE_MODULE`             | (none)               |
+| `DYNAMIC_CONFIG_MODULE`  | (none)               |
+| `TCP_REASSEMBLY_MODULE`  | (none)               |
+| `HTTP_RECONSTRUCT_MODULE`| (none, implies TCP)  |
+| `FTP_RECONSTRUCT_MODULE` | (none, implies TCP)  |
+
+Example with multiple modules:
+
+```bash
+make -j$(nproc) KAFKA_MODULE REDIS_MODULE SECURITY_MODULE PCAP_DUMP_MODULE QOS_MODULE SOCKET_MODULE compile
+```
+
+#### 4c. Build with ALL Modules
+
+```bash
+make -j$(nproc) ALL_MODULES compile
+```
+
+> **Note**: `ALL_MODULES` requires all optional libraries from Step 3 to be installed.
+
+#### 4d. Build with DPDK Capture (instead of PCAP)
+
+```bash
+export RTE_SDK=/path/to/dpdk
+export RTE_TARGET=build
+make -j$(nproc) DPDK_CAPTURE compile
+```
+
+#### Build Options
+
+| Option         | Effect                                         |
+|----------------|-------------------------------------------------|
+| `DEBUG`        | Enable debug symbols (`-g -O0`) for gdb         |
+| `VERBOSE`      | Print detailed compilation commands              |
+| `STATIC_LINK`  | Embed MMT-DPI and MMT-Security into the binary   |
+| `DISABLE_REPORT`| Skip DPI statistics (for security/dump only)   |
+| `SIMPLE_REPORT`| Minimal session reports (for MMT-Box)           |
+| `MMT_BASE=/path`| Custom installation prefix (default: /opt/mmt) |
+
+#### Verification
+
+```bash
+./probe -v   # Should print version: 1.6.0 and git hash
+./probe -h   # Should print usage help
+```
+
+---
+
+### 5. Install MMT-Probe
+
+```bash
+sudo make install
+# Or with modules:
+sudo make KAFKA_MODULE REDIS_MODULE SECURITY_MODULE install
+```
+
+This installs to `/opt/mmt/probe/` (or `$MMT_BASE/probe/` if `MMT_BASE` is set):
+
+```
+/opt/mmt/probe/
+├── bin/probe              # Executable
+├── mmt-probe.conf         # Configuration file
+└── result/report/online/  # Default report output directory
+```
+
+#### Create Packages (optional)
+
+```bash
+# Debian/Ubuntu .deb package
+make deb
+# or with modules:
+make KAFKA_MODULE REDIS_MODULE deb
+
+# RHEL/CentOS .rpm package
+make rpm
+```
+
+#### Verification
+
+```bash
+ls -la /opt/mmt/probe/bin/probe
+/opt/mmt/probe/bin/probe -v
+```
+
+---
+
+### 6. Configuration
+
+The default configuration file is `mmt-probe.conf`. After installation it is located at `/opt/mmt/probe/mmt-probe.conf`.
+
+#### Key Configuration Sections
+
+| Section            | Purpose                                 | Default State |
+|--------------------|-----------------------------------------|---------------|
+| `input`            | Capture source (interface or PCAP file) | `enp0s3`      |
+| `file-output`      | Write reports to files                  | **enabled**   |
+| `redis-output`     | Publish reports to Redis                | disabled      |
+| `kafka-output`     | Publish reports to Kafka                | disabled      |
+| `mongodb-output`   | Store reports in MongoDB                | disabled      |
+| `mqtt-output`      | Publish reports via MQTT                | disabled      |
+| `socket-output`    | Send reports via Unix/TCP/UDP socket    | disabled      |
+| `security`         | MMT-Security rule verification          | disabled      |
+| `session-report`   | Per-session DPI statistics              | **enabled**   |
+| `dump-pcap`        | Dump packets to PCAP files              | disabled      |
+| `thread-nb`        | Number of processing threads            | `0` (single)  |
+
+#### Minimal Configuration Adjustments
+
+At minimum, update the capture interface:
+
+```
+input {
+    mode = ONLINE
+    source = "<YOUR_INTERFACE>"   # e.g., "eth0", "ens33"
+}
+```
+
+Configuration can also be overridden at runtime via `-X` flags:
+
+```bash
+sudo ./probe -i eth0 -Xfile-output.enable=true -Xfile-output.output-dir=/tmp/
+```
+
+#### List All Overridable Parameters
+
+```bash
+./probe -x
+```
+
+---
+
+### 7. Execution
+
+#### 7a. Run Locally (foreground)
+
+```bash
+# Live capture on an interface
+sudo ./probe -i eth0
+
+# Offline analysis of a PCAP file
+sudo ./probe -t /path/to/capture.pcap
+
+# With a specific configuration file
+sudo ./probe -c mmt-probe.conf
+
+# Override config parameters at runtime
+sudo ./probe -i eth0 -Xfile-output.enable=true -Xsecurity.enable=true
+```
+
+#### 7b. Run as a Systemd Service
+
+Available only when installed to the default path `/opt/mmt/probe/`.
+
+```bash
+sudo systemctl start mmt-probe
+sudo systemctl status mmt-probe
+sudo systemctl stop mmt-probe
+
+# View logs
+journalctl -t mmt-probe
+```
+
+#### 7c. Run with Docker
+
+```bash
+# Pull the image
+docker pull ghcr.io/montimage/mmt-probe:latest
+
+# Run with live capture
+docker run --network=host ghcr.io/montimage/mmt-probe:latest \
+    mmt-probe -i eth0 -Xfile-output.enable=true
+
+# Run with a PCAP file
+docker run -v /path/to/pcaps:/data ghcr.io/montimage/mmt-probe:latest \
+    mmt-probe -t /data/capture.pcap
+```
+
+#### 7d. Build Docker Image from Source
+
+```bash
+cd /path/to/mmt-probe
+docker build -t mmt-probe:local .
+```
+
+---
+
+### 8. Verification Steps
+
+Run these after installation to confirm everything is working:
+
+```bash
+# 1. Check the binary exists and runs
+/opt/mmt/probe/bin/probe -v
+# Expected: prints version info (e.g., "mmt-probe 1.6.0 ...")
+
+# 2. Check help output
+/opt/mmt/probe/bin/probe -h
+# Expected: prints usage with -v, -c, -t, -i, -X, -x, -h options
+
+# 3. Test offline analysis with sample PCAP
+sudo /opt/mmt/probe/bin/probe -t test/UA-Exp01.pcap -Xfile-output.output-dir=/tmp/mmt-test/
+# Expected: processes packets and generates report files in /tmp/mmt-test/
+
+# 4. Verify report output was created
+ls -la /tmp/mmt-test/
+# Expected: CSV or JSON report files
+
+# 5. Check linked libraries (runtime dependencies)
+ldd /opt/mmt/probe/bin/probe
+# Expected: all shared libraries resolved (no "not found")
+
+# 6. Check systemd service (if installed to /opt/mmt/probe/)
+sudo systemctl status mmt-probe
+# Expected: loaded (may be inactive if not started)
+```
+
+---
+
+## Manual Input Summary
+
+| Input               | Description                                       | Required | Default             |
+|---------------------|---------------------------------------------------|----------|---------------------|
+| Network interface   | Interface name for live capture                   | Yes*     | `enp0s3`            |
+| PCAP file path      | Path to PCAP file for offline analysis            | Yes*     | -                   |
+| `MMT_BASE`          | Custom installation prefix                        | No       | `/opt/mmt`          |
+| Module selection    | Which optional modules to enable                  | No       | File output + PCAP  |
+| Output endpoints    | Redis/Kafka/MongoDB/MQTT server addresses         | No       | `localhost`         |
+| Thread count        | Number of processing threads                      | No       | `0` (single thread) |
+
+\* Either a network interface or PCAP file path is required for execution.
+
+---
+
+## Permission Gates
+
+The following operations require explicit user permission:
+
+- [ ] **Install system packages** (`apt-get install`, `yum install`)
+- [ ] **Clone external repositories** (MMT-DPI, MMT-Security, hiredis, librdkafka, mongo-c-driver)
+- [ ] **Run `make install` with sudo** (writes to `/opt/mmt/` and `/usr/local/`)
+- [ ] **Run `ldconfig` with sudo** (updates shared library cache)
+- [ ] **Modify system configuration** (systemd service file)
+- [ ] **Set network interface to promiscuous mode** (via `probe -i`)
+- [ ] **Create/modify `/opt/mmt/probe/mmt-probe.conf`** (runtime configuration)
+
+---
+
+## Environment Variables Reference
+
+### Build-Time
+
+| Variable           | Description                                  | Default       |
+|--------------------|----------------------------------------------|---------------|
+| `MMT_BASE`         | Base installation directory for MMT tools    | `/opt/mmt`    |
+| `MMT_DPI_DIR`      | Path to MMT-DPI installation                 | `$MMT_BASE/dpi` |
+| `MMT_SECURITY_DIR` | Path to MMT-Security installation            | `$MMT_BASE/security` |
+| `RTE_SDK`          | DPDK SDK path (DPDK mode only)               | _(unset)_     |
+| `RTE_TARGET`       | DPDK build target (DPDK mode only)           | `build`       |
+| `DEBIAN_FRONTEND`  | Suppress apt interactive prompts             | _(unset)_     |
+
+### Runtime (Docker/Environment)
+
+| Variable                                          | Description                          |
+|---------------------------------------------------|--------------------------------------|
+| `MMT_SEC_5G_DOS_NGAP_INITIALUEMESSAGE_MS_LIMIT`  | 5G DoS detection threshold (ms)      |
+| `MMT_SEC_5G_DOS_HTTP2_MS_LIMIT`                   | 5G HTTP/2 DoS detection threshold    |
+
+---
+
+## Automated Installation (One-Command)
+
+For a fully automated installation with all modules on Debian/Ubuntu:
+
+```bash
+sudo ./script/install-from-source.sh
+```
+
+This script:
+1. Installs all system dependencies
+2. Clones and installs hiredis v1.0.2
+3. Clones and installs librdkafka v1.8.2
+4. Downloads and installs mongo-c-driver 1.9.5
+5. Installs libpaho-mqtt
+6. Clones and installs MMT-DPI
+7. Clones and installs MMT-Security
+8. Compiles MMT-Probe with all modules (`KAFKA_MODULE MONGODB_MODULE PCAP_DUMP_MODULE QOS_MODULE REDIS_MODULE MQTT_MODULE SECURITY_MODULE SOCKET_MODULE LTE_MODULE`)
+9. Creates a `.deb` package
+
+> **Requires**: Root privileges, Ubuntu/Debian, and internet access.
+
+---
+
+## Troubleshooting
+
+### Compilation Errors
+
+| Error                                          | Cause                              | Solution                                       |
+|------------------------------------------------|------------------------------------|-------------------------------------------------|
+| `ERROR: Not found MMT-DPI at folder /opt/mmt/dpi` | MMT-DPI not installed           | Install MMT-DPI first (Step 2)                  |
+| `Not found MMT-Security at /opt/mmt/security`  | MMT-Security not installed        | Install MMT-Security (Step 3e) or remove `SECURITY_MODULE` |
+| `-lhiredis` not found                          | hiredis not installed              | Install hiredis (Step 3a) or remove `REDIS_MODULE` |
+| `-lrdkafka` not found                          | librdkafka not installed           | Install librdkafka (Step 3b) or remove `KAFKA_MODULE` |
+| `-lmongoc-1.0` not found                       | mongo-c-driver not installed       | Install mongo-c-driver (Step 3c) or remove `MONGODB_MODULE` |
+| `-lpaho-mqtt3c` not found                       | libpaho-mqtt not installed        | Install libpaho-mqtt (Step 3d) or remove `MQTT_MODULE` |
+
+### Runtime Errors
+
+| Error                                          | Cause                              | Solution                                       |
+|------------------------------------------------|------------------------------------|-------------------------------------------------|
+| `error while loading shared libraries`         | Library not in LD path             | Run `sudo ldconfig`                             |
+| `Permission denied` on interface               | Missing root/CAP_NET_RAW           | Run with `sudo` or set capabilities             |
+| No output files generated                      | `file-output.enable` is false      | Set `-Xfile-output.enable=true`                 |
+| Probe exits immediately                        | License check enabled but no key   | Remove `LICENSE_MODULE` or provide `license.key` |
+
+### Common Issues
+
+- **Clean build after module changes**: Run `make clean` before recompiling with different modules.
+- **Library path issues**: Ensure `/usr/local/lib` is in the linker path. Check with `ldconfig -p | grep <lib>`.
+- **DPDK hugepages**: Allocate hugepages before running DPDK mode: `echo 1024 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages`.
+
+---
+
+## Next Steps
+
+After successful setup:
+
+1. **Configure for your network**: Edit `mmt-probe.conf` to set your capture interface and enable desired reports/outputs.
+2. **Integrate with MMT-Operator**: Connect to the [MMT-Operator](https://github.com/montimage/mmt-operator) web interface for visualization.
+3. **Add security rules**: Enable `SECURITY_MODULE` and configure custom rules for intrusion detection.
+4. **Deploy at scale**: Use Docker Compose or Kubernetes manifests in `docs/guide/k8s/` for production deployments.
+5. **Monitor performance**: Use `system-report` in the config to track CPU/memory usage of the probe itself.
+
+---
+
+## Quick Reference: Common Commands
+
+```bash
+# Compile (minimal)
+make compile
+
+# Compile (all modules)
+make ALL_MODULES compile
+
+# Install
+sudo make install
+
+# Run on interface
+sudo ./probe -i eth0
+
+# Run on PCAP file
+sudo ./probe -t file.pcap
+
+# Run with config
+sudo ./probe -c mmt-probe.conf
+
+# Override config at runtime
+sudo ./probe -i eth0 -Xsecurity.enable=true -Xfile-output.output-dir=/tmp/
+
+# Create .deb package
+make deb
+
+# Clean build
+make clean
+
+# View service logs
+journalctl -t mmt-probe
+```

--- a/skills/mmt-configure/SKILL.md
+++ b/skills/mmt-configure/SKILL.md
@@ -1,0 +1,430 @@
+---
+name: mmt-configure
+version: 1.0.0
+description: Configure MMT-Probe input, output channels, reports, security, and performance tuning
+---
+
+# MMT-Probe Configuration
+
+Guide the user through configuring MMT-Probe for their specific use case.
+
+## Triggers
+
+Use this skill when the user asks to:
+- Configure MMT-Probe or edit mmt-probe.conf
+- Set up input source (interface, PCAP file)
+- Enable or configure output channels (file, Redis, Kafka, MongoDB, MQTT, socket)
+- Configure reports (session, event, security, query)
+- Tune performance (threads, queues, timeouts)
+- Override configuration at runtime
+
+## Configuration Basics
+
+MMT-Probe uses **libconfuse** format for its configuration file.
+
+### Config file search order
+
+1. Path given via `-c <path>` CLI option
+2. `./mmt-probe.conf` in the current working directory
+3. `/opt/mmt/probe/mmt-probe.conf` (installed default)
+
+If no config file is found, the probe stops.
+
+### Runtime override with `-X`
+
+Any configuration parameter can be overridden at runtime:
+
+```bash
+sudo ./probe -i eth0 -Xfile-output.enable=true -Xfile-output.output-dir=/tmp/
+```
+
+### List all overridable parameters
+
+```bash
+./probe -x
+```
+
+## Global Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `probe-id` | int | `3` | Unique identifier for this probe instance |
+| `stack-type` | int | `1` | Root protocol stack: `1`=Ethernet, `800`=IEEE 802.15.4, `624`=Linux cooked |
+| `stack-offset` | int | `0` | Byte offset into the packet |
+| `license` | string | `"./license.key"` | Path to license key file |
+| `enable-proto-without-session-report` | bool | `false` | Report non-IP traffic (ARP, PPP) |
+| `enable-ip-fragmentation-report` | bool | `false` | Report IP fragmentation info |
+| `enable-ip-defragmentation` | bool | `false` | Perform IP defragmentation |
+| `enable-tcp-reassembly` | bool | `false` | Reassemble TCP segments (requires ip-defrag) |
+| `enable-report-version-info` | bool | `true` | Print probe version to output channels |
+| `stats-period` | int | `5` | Statistics sampling period in seconds |
+
+## Input Configuration
+
+```
+input {
+    mode = ONLINE            # ONLINE (live) or OFFLINE (pcap file)
+    source = "eth0"          # Interface name or PCAP file path
+    snap-len = 0             # Max packet size (0 = 65535 default)
+    buffer-size = 4096       # PCAP buffer size in bytes
+    timeout = 1000           # PCAP buffer timeout in milliseconds
+    dpdk-option = ""         # DPDK EAL options (DPDK mode only)
+    pcap-filter = ""         # BPF filter (PCAP mode only)
+}
+```
+
+### BPF filter examples
+
+| Filter | Description |
+|--------|-------------|
+| `"tcp port 80"` | TCP traffic on port 80 |
+| `"udp port 53"` | DNS queries |
+| `"host 192.168.1.1"` | All traffic to/from a host |
+| `"src net 192.168.0.0/16"` | Packets from a subnet |
+| `"tcp and not port 22"` | TCP excluding SSH |
+
+### DPDK multi-port input
+
+In DPDK mode, use comma-separated port numbers: `source = "0,1"`. Traffic is aggregated across ports.
+
+## Output Format and Cache
+
+```
+output {
+    format = CSV             # CSV or JSON
+    cache-max = 100000       # Max messages in cache before flush
+    cache-period = 5         # Flush interval in seconds
+}
+```
+
+The cache is flushed when full OR when `cache-period` elapses. For file output with `sample-file=true`, a new file is created each `cache-period` seconds.
+
+## Output Channels
+
+### File Output
+
+```
+file-output {
+    enable = true
+    output-file = "data.csv"
+    output-dir = "/opt/mmt/probe/result/report/online"
+    sample-file = true       # Create new file each cache-period
+    retain-files = 80        # Keep last N files (0 = keep all)
+}
+```
+
+> `retain-files` must be greater than `thread-nb + 1`.
+
+### Redis Output
+
+Requires: `REDIS_MODULE` + hiredis v1.0.2
+
+```
+redis-output {
+    enable = true
+    hostname = "localhost"
+    port = 6379
+    channel = "report"       # Redis pub/sub channel name
+}
+```
+
+### Kafka Output
+
+Requires: `KAFKA_MODULE` + librdkafka v1.8.2
+
+```
+kafka-output {
+    enable = true
+    hostname = "localhost"
+    port = 9092
+    topic = "report"         # Kafka topic name
+}
+```
+
+### MongoDB Output
+
+Requires: `MONGODB_MODULE` + mongo-c-driver 1.9.5
+
+```
+mongodb-output {
+    enable = true
+    hostname = "localhost"
+    port = 27017
+    database = "mmt-data"
+    collection = "reports"
+    limit-size = 0           # Max collection size in MB (0 = unlimited)
+}
+```
+
+When `limit-size` is set, oldest reports are removed to maintain the limit.
+
+### MQTT Output
+
+Requires: `MQTT_MODULE` + libpaho-mqtt
+
+```
+mqtt-output {
+    enable = true
+    address = "tcp://localhost:1883"   # protocol://host:port
+    topic = "report"
+    retain = false
+}
+```
+
+Supported protocols: `tcp://`, `mqtt://`, `ssl://`, `mqtts://`, `ws://`, `wss://`
+
+### Socket Output
+
+Requires: `SOCKET_MODULE`
+
+```
+socket-output {
+    enable = true
+    type = BOTH              # UNIX, TCP, UDP, or BOTH (UNIX+TCP)
+    descriptor = "/tmp/mmt-probe-output.sock"  # UNIX socket path
+    hostname = "127.0.0.1"   # TCP/UDP host
+    port = 5000              # TCP/UDP port
+}
+```
+
+## Report Configuration
+
+### Session Report (format ID 100)
+
+```
+session-report {
+    enable = true
+    output-channel = {file}  # {file, redis, kafka, mongodb, socket, mqtt}
+    ftp = false
+    http = true
+    rtp = false
+    ssl = true
+    gtp = false
+    rtt-base = CAPTOR        # CAPTOR, SENDER, or PREFER_SENDER
+}
+```
+
+### Event Report (format ID 1000)
+
+Custom event-triggered reports. Name must be unique.
+
+```
+event-report my-events {
+    enable = true
+    event = "ip.src"
+    attributes = {"ip.src", "ip.dst", "meta.proto_hierarchy"}
+    output-channel = {file}
+}
+```
+
+With custom output format (replaces `attributes`):
+
+```
+event-report ip-json {
+    enable = true
+    event = "ip.src"
+    output-format = '{"source": "ip.src", "destination": "ip.dst"}'
+    output-channel = {socket, stdout}
+}
+```
+
+With delta condition (report only on change):
+
+```
+event-report int {
+    enable = true
+    event = "int.latency"
+    delta-cond = {"int.num_hop", "int.hop_switch_ids"}
+    attributes = {"ip.src", "ip.dst", "int.num_hop", "int.hop_latencies"}
+    output-channel = {}
+}
+```
+
+### Query Report
+
+SQL-like aggregation over packet streams.
+
+```
+query-report avg-udp {
+    enable = true
+    ms-period = 33           # Report interval in milliseconds
+    output-channel = {socket}
+    select = {"last(ip.src)", "avg(meta.packet_len)", "count(meta.packet_index)"}
+    where = {"udp.len"}      # Only process UDP packets
+    group-by = {"ip.src", "ip.dst"}
+}
+```
+
+Supported operators: `sum`, `count`, `avg`, `var`, `diff`, `last`, `first`
+
+### Security Report (format ID 10)
+
+Requires: `SECURITY_MODULE`
+
+```
+security {
+    enable = true
+    thread-nb = 1
+    exclude-rules = ""
+    rules-mask = ""          # e.g., "(1:1,2,4-6)(2:3)"
+    output-channel = {file}
+    report-rule-description = true
+    ignore-remain-flow = true
+    input.max-message-size = 60000
+    security.max-instances = 100000
+    security.smp.ring-size = 1000
+    ip-encapsulation-index = LAST  # FIRST, LAST, or N
+}
+```
+
+### System Report (format ID 201)
+
+```
+system-report {
+    enable = true
+    period = 5               # Reporting period in seconds
+    output-channel = {}
+}
+```
+
+## Performance Tuning
+
+### Threading
+
+```
+thread-nb = 0                # 0=single thread, 1+=multi-thread
+thread-queue = 262144        # Max packets queued per thread
+```
+
+- `thread-nb = 0`: one thread reads and processes packets
+- `thread-nb = 1`: one thread reads, another processes
+- `thread-nb = N`: one reader thread, N processing threads
+
+If a thread's queue is full, incoming packets are dropped.
+
+### Session Timeouts
+
+```
+session-timeout {
+    default-session-timeout = 60
+    short-session-timeout = 15
+    long-session-timeout = 6000    # Web/SSL with long polling
+    live-session-timeout = 1500    # Persistent connections
+}
+```
+
+## Advanced Features
+
+### Dynamic Configuration
+
+Requires: `DYNAMIC_CONFIG_MODULE`
+
+```
+dynamic-config {
+    enable = true
+    descriptor = "/tmp/mmt.sock"
+}
+```
+
+Allows runtime control via Unix socket. See `/mmt-operate` for commands.
+
+### PCAP Dump
+
+Requires: `PCAP_DUMP_MODULE`
+
+```
+dump-pcap {
+    enable = true
+    output-dir = "/opt/mmt/probe/pcaps/"
+    protocols = {"unknown"}  # Protocols to dump
+    period = 60              # New file every N seconds
+    retain-files = 50
+    snap-len = 65355
+}
+```
+
+### Data Reconstruction
+
+Requires: `enable-tcp-reassembly = true` and `enable-ip-defragmentation = true`
+
+```
+reconstruct-data http {
+    enable = true
+    output-dir = "/tmp/"
+    output-channel = {}
+}
+
+reconstruct-data ftp {
+    enable = true
+    output-dir = "/tmp/"
+    output-channel = {}
+}
+```
+
+### Micro-flows
+
+Aggregate small flows by protocol ID to reduce report volume.
+
+```
+micro-flows {
+    enable = true
+    packet-threshold = 2
+    byte-threshold = 100
+    report-packet-count = 1000
+    report-byte-count = 10000
+    report-flow-count = 500
+    output-channel = {}
+}
+```
+
+## Common Configuration Recipes
+
+### High-throughput monitoring
+
+```bash
+sudo ./probe -i eth0 \
+  -Xthread-nb=4 \
+  -Xthread-queue=524288 \
+  -Xoutput.cache-max=500000 \
+  -Xsession-report.enable=true \
+  -Xfile-output.enable=true \
+  -Xfile-output.output-dir=/data/mmt/
+```
+
+### Security analysis
+
+```bash
+sudo ./probe -i eth0 \
+  -Xsecurity.enable=true \
+  -Xsecurity.thread-nb=2 \
+  -Xsession-report.ssl=true \
+  -Xfile-output.enable=true
+```
+
+### Kafka streaming pipeline
+
+```bash
+sudo ./probe -i eth0 \
+  -Xkafka-output.enable=true \
+  -Xkafka-output.hostname=kafka-broker \
+  -Xkafka-output.port=9092 \
+  -Xkafka-output.topic=mmt-reports \
+  -Xsession-report.output-channel={kafka}
+```
+
+### Offline forensic analysis
+
+```bash
+sudo ./probe -t /path/to/capture.pcap \
+  -Xfile-output.enable=true \
+  -Xfile-output.output-dir=/tmp/analysis/ \
+  -Xsession-report.http=true \
+  -Xsession-report.ssl=true \
+  -Xsession-report.ftp=true
+```
+
+## Cross-references
+
+- To install MMT-Probe and its dependencies, use `/mmt-install`.
+- To run the probe and understand output, use `/mmt-operate`.
+- For general help and troubleshooting, use `/mmt-help`.

--- a/skills/mmt-configure/SKILL.md
+++ b/skills/mmt-configure/SKILL.md
@@ -18,6 +18,10 @@ Use this skill when the user asks to:
 - Tune performance (threads, queues, timeouts)
 - Override configuration at runtime
 
+## Important: Docker / Non-root Environments
+
+Inside Docker containers you typically run as root, so `sudo` is not needed and may not be available. **Omit `sudo` from all commands when running inside Docker.** All commands below show `sudo` for host use; drop it in containers.
+
 ## Configuration Basics
 
 MMT-Probe uses **libconfuse** format for its configuration file.
@@ -35,7 +39,7 @@ If no config file is found, the probe stops.
 Any configuration parameter can be overridden at runtime:
 
 ```bash
-sudo ./probe -i eth0 -Xfile-output.enable=true -Xfile-output.output-dir=/tmp/
+./probe -i eth0 -Xfile-output.enable=true -Xfile-output.output-dir=/tmp/
 ```
 
 ### List all overridable parameters
@@ -382,7 +386,7 @@ micro-flows {
 ### High-throughput monitoring
 
 ```bash
-sudo ./probe -i eth0 \
+./probe -i eth0 \
   -Xthread-nb=4 \
   -Xthread-queue=524288 \
   -Xoutput.cache-max=500000 \
@@ -394,7 +398,7 @@ sudo ./probe -i eth0 \
 ### Security analysis
 
 ```bash
-sudo ./probe -i eth0 \
+./probe -i eth0 \
   -Xsecurity.enable=true \
   -Xsecurity.thread-nb=2 \
   -Xsession-report.ssl=true \
@@ -404,7 +408,7 @@ sudo ./probe -i eth0 \
 ### Kafka streaming pipeline
 
 ```bash
-sudo ./probe -i eth0 \
+./probe -i eth0 \
   -Xkafka-output.enable=true \
   -Xkafka-output.hostname=kafka-broker \
   -Xkafka-output.port=9092 \
@@ -415,7 +419,7 @@ sudo ./probe -i eth0 \
 ### Offline forensic analysis
 
 ```bash
-sudo ./probe -t /path/to/capture.pcap \
+./probe -t /path/to/capture.pcap \
   -Xfile-output.enable=true \
   -Xfile-output.output-dir=/tmp/analysis/ \
   -Xsession-report.http=true \

--- a/skills/mmt-help/SKILL.md
+++ b/skills/mmt-help/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: mmt-help
+version: 1.0.0
+description: General help for MMT-Probe — architecture, protocols, modules, troubleshooting, and ecosystem
+---
+
+# MMT-Probe Help
+
+Provide general information about MMT-Probe, its architecture, capabilities, and troubleshooting guidance.
+
+## Triggers
+
+Use this skill when the user asks:
+- What is MMT-Probe / what can MMT do
+- About the architecture or how it works
+- About supported protocols or modules
+- For troubleshooting help (errors, crashes, performance)
+- About the MMT ecosystem
+- General questions not covered by install/configure/operate skills
+
+## What is MMT-Probe
+
+MMT-Probe is a C-based network traffic analysis probe developed by [Montimage](https://www.montimage.com).
+
+- **Repository**: https://github.com/montimage/mmt-probe
+- **Version**: 1.6.x
+- **License**: Apache License 2.0
+- **Language**: C
+- **Platforms**: Linux (Ubuntu, Debian, CentOS, Fedora), Docker
+
+### Capabilities
+
+- Deep Packet Inspection (DPI) via MMT-DPI library
+- Real-time and offline (PCAP) traffic analysis
+- Protocol classification and application identification
+- Session-based flow statistics with QoS metrics
+- Security rule verification via MMT-Security
+- Multi-output: files, Redis, Kafka, MongoDB, MQTT, sockets
+- HTTP/FTP data reconstruction
+- PCAP packet dumping by protocol
+- Custom event and query-based reporting
+- Dynamic runtime configuration via Unix socket
+- LTE/5G mobile network analysis (eNodeB, GTP, QFI)
+
+## Architecture
+
+MMT-Probe uses a **3-process model**:
+
+```
+start =========== monitor proc ================>> end
+       |\                            |  |
+       | '======= processing proc ==='  |
+       |                                |
+       '========= control proc ========='
+```
+
+1. **Monitor process** (root): Creates and monitors children. Restarts a child if it crashes.
+2. **Processing process**: Main packet processing. Reads traffic, performs DPI, generates reports.
+3. **Control process** (optional): Listens on a Unix domain socket for runtime control commands. Requires `DYNAMIC_CONFIG_MODULE`.
+
+### Multi-threading
+
+Within the processing process:
+- `thread-nb = 0`: Single thread reads and processes packets
+- `thread-nb = 1`: One thread reads, one thread processes
+- `thread-nb = N`: One reader thread dispatches to N processing threads
+
+Packets are dispatched to threads by flow (same flow always goes to same thread). If a thread's queue is full, the packet is dropped.
+
+## Module System
+
+Modules are selected at compile time via make targets.
+
+| Module | Description | External Dependency |
+|--------|-------------|---------------------|
+| `QOS_MODULE` | QoS metrics (RTT, response time) | None |
+| `REDIS_MODULE` | Redis pub/sub output | hiredis v1.0.2 |
+| `KAFKA_MODULE` | Kafka output | librdkafka v1.8.2 |
+| `MONGODB_MODULE` | MongoDB output | mongo-c-driver 1.9.5 |
+| `MQTT_MODULE` | MQTT output | libpaho-mqtt |
+| `SOCKET_MODULE` | Unix/TCP/UDP socket output | None |
+| `SECURITY_MODULE` | Security rule verification | MMT-Security + libxml2 |
+| `PCAP_DUMP_MODULE` | Dump packets to PCAP files | None |
+| `LTE_MODULE` | LTE eNodeB reporting | None |
+| `DYNAMIC_CONFIG_MODULE` | Runtime control via Unix socket | None |
+| `TCP_REASSEMBLY_MODULE` | TCP segment reassembly | None |
+| `HTTP_RECONSTRUCT_MODULE` | Reconstruct HTTP payload | None (implies TCP) |
+| `FTP_RECONSTRUCT_MODULE` | Reconstruct FTP files | None (implies TCP) |
+| `LICENSE_MODULE` | License key verification | None |
+| `NETCONF_MODULE` | NETCONF protocol support | sysrepo + libxml2 (implies DYNAMIC_CONFIG) |
+
+Compile with `ALL_MODULES` to enable everything (all dependencies must be installed).
+
+### Module dependencies
+
+- `HTTP_RECONSTRUCT_MODULE` automatically enables `TCP_REASSEMBLY_MODULE`
+- `FTP_RECONSTRUCT_MODULE` automatically enables `TCP_REASSEMBLY_MODULE`
+- `TCP_REASSEMBLY_MODULE` requires `enable-tcp-reassembly = true` + `enable-ip-defragmentation = true` in config
+- `NETCONF_MODULE` automatically enables `DYNAMIC_CONFIG_MODULE`
+- `DPDK_CAPTURE` and `STATIC_LINK` cannot be used together
+
+## Supported Protocols
+
+MMT-Probe identifies protocols via MMT-DPI. Categories include:
+
+### Link Layer
+Ethernet, IEEE 802.15.4, Linux cooked capture, ARP, PPP
+
+### Network Layer
+IPv4, IPv6, ICMP, ICMPv6, GRE, GTP
+
+### Transport Layer
+TCP, UDP, SCTP
+
+### Application Layer
+HTTP, HTTPS/SSL/TLS, DNS, FTP, SSH, SMTP, IMAP, POP3, RTP, RTSP, SIP, DHCP, NTP, SNMP, MQTT, CoAP, and 700+ application signatures (Facebook, YouTube, Netflix, etc.)
+
+### Telco/5G
+S1AP, NGAP, NAS, GTP-U, GTP-C, PFCP, Diameter, RADIUS
+
+## Quick Reference
+
+### Stack Types
+
+| Value | Protocol |
+|-------|----------|
+| 1 | Ethernet |
+| 624 | Linux cooked capture |
+| 800 | IEEE 802.15.4 |
+
+### Report Format IDs
+
+| ID | Report Type |
+|----|-------------|
+| 1 | Startup (probe version info) |
+| 10 | Security alerts |
+| 30 | License status |
+| 99 | Protocol statistics (non-session) |
+| 100 | Session flow statistics |
+| 200 | Probe status / liveness |
+| 201 | System CPU/memory info |
+| 301 | HTTP reconstruction metadata |
+| 400 | eNodeB topology events |
+| 401 | eNodeB QoS (bearer allocation) |
+| 1000 | Custom event reports |
+
+### Output Formats
+
+| Format | Description |
+|--------|-------------|
+| CSV | Comma-separated, strings in `"`, complex values in `[]` |
+| JSON | JSON objects |
+
+### Session Sub-format IDs (within report 100)
+
+| Sub-ID | Protocol | Extra Fields |
+|--------|----------|--------------|
+| 0 | Default | None |
+| 1 | HTTP | Response time, hostname, MIME, URI, method, status |
+| 2 | SSL | Server name, CDN flag |
+| 3 | RTP | Loss rate, burstiness, jitter, order errors |
+| 4 | FTP | Username, password, file info |
+| 5 | GTP | Outer IP, TEIDs |
+
+## Troubleshooting Guide
+
+### Compilation Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `ERROR: Not found MMT-DPI at folder /opt/mmt/dpi` | MMT-DPI not installed | Install MMT-DPI first |
+| `Not found MMT-Security at /opt/mmt/security` | MMT-Security missing | Install it or remove `SECURITY_MODULE` |
+| `-lhiredis` / `-lrdkafka` / `-lmongoc-1.0` not found | Library not installed | Install the library or remove the module |
+| Undefined reference errors after module change | Stale object files | Run `make clean` before recompiling |
+
+### Runtime Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `error while loading shared libraries` | Library not in LD path | Run `sudo ldconfig` |
+| `Permission denied` on interface | Missing root privileges | Run with `sudo` or set `CAP_NET_RAW` capability |
+| Probe exits immediately | License check with no key | Remove `LICENSE_MODULE` or provide `license.key` |
+| No config file found | Missing mmt-probe.conf | Use `-c <path>` or place config in `./` or `/opt/mmt/probe/` |
+
+### No Output
+
+1. Check `file-output.enable` is `true`
+2. Check `file-output.output-dir` exists and is writable
+3. Check `session-report.enable` is `true`
+4. For non-file channels, verify the channel is globally enabled
+5. For offline mode, verify the PCAP file has traffic matching your config
+
+### Packet Drops
+
+1. Check status reports (ID 200) for `nic-lost` and `mmt-lost` counts
+2. Increase `thread-nb` to add processing threads
+3. Increase `thread-queue` to buffer more packets per thread
+4. Increase `input.buffer-size` for NIC-level buffering
+5. Apply BPF filters to reduce packet volume
+6. Consider DPDK mode for high-throughput scenarios
+
+### High Memory Usage
+
+1. Reduce `session-timeout` values
+2. Reduce `output.cache-max`
+3. Enable `micro-flows` to aggregate small flows
+4. Disable unused session sub-reports (HTTP, SSL, RTP, FTP, GTP)
+
+## MMT Ecosystem
+
+| Component | Description | Repository |
+|-----------|-------------|------------|
+| **MMT-DPI** | Deep Packet Inspection library (core dependency) | [montimage/mmt-dpi](https://github.com/montimage/mmt-dpi) |
+| **MMT-Probe** | Network traffic analysis probe (this project) | [montimage/mmt-probe](https://github.com/montimage/mmt-probe) |
+| **MMT-Security** | Security rule verification engine | [Montimage/mmt-security](https://github.com/Montimage/mmt-security) |
+| **MMT-Operator** | Web dashboard for visualization | [montimage/mmt-operator](https://github.com/montimage/mmt-operator) |
+| **5Greplay** | 5G traffic replay and testing | [montimage/5greplay](https://github.com/montimage/5greplay) |
+
+### Typical deployment
+
+```
+Network Traffic -> MMT-Probe -> [Kafka/Redis/Files] -> MMT-Operator (Web UI)
+                      |
+                  MMT-Security (rule engine)
+```
+
+## Environment Variables
+
+### Build-Time
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MMT_BASE` | `/opt/mmt` | Base installation directory |
+| `MMT_DPI_DIR` | `$MMT_BASE/dpi` | MMT-DPI installation path |
+| `MMT_SECURITY_DIR` | `$MMT_BASE/security` | MMT-Security installation path |
+| `RTE_SDK` | (unset) | DPDK SDK path |
+| `RTE_TARGET` | `build` | DPDK build target |
+
+### System Requirements
+
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| OS | Linux (x86_64) | Ubuntu 22.04 |
+| RAM | 100 MB | 2 GB+ (DPDK) |
+| Disk | ~50 MB | + space for reports |
+| Privileges | root or `CAP_NET_RAW` | root |
+
+## Cross-references
+
+- To install MMT-Probe, use `/mmt-install`.
+- To configure the probe, use `/mmt-configure`.
+- To run and monitor the probe, use `/mmt-operate`.

--- a/skills/mmt-help/SKILL.md
+++ b/skills/mmt-help/SKILL.md
@@ -177,8 +177,9 @@ S1AP, NGAP, NAS, GTP-U, GTP-C, PFCP, Diameter, RADIUS
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| `error while loading shared libraries` | Library not in LD path | Run `sudo ldconfig` |
-| `Permission denied` on interface | Missing root privileges | Run with `sudo` or set `CAP_NET_RAW` capability |
+| `error while loading shared libraries` | Library not in LD path | Run `ldconfig` (or `sudo ldconfig` on host) |
+| `Permission denied` on interface | Missing root privileges | Run with `sudo` on host, or use `--network=host` in Docker |
+| `sudo: command not found` | Running inside Docker | Omit `sudo` — you are already root in Docker |
 | Probe exits immediately | License check with no key | Remove `LICENSE_MODULE` or provide `license.key` |
 | No config file found | Missing mmt-probe.conf | Use `-c <path>` or place config in `./` or `/opt/mmt/probe/` |
 
@@ -243,7 +244,7 @@ Network Traffic -> MMT-Probe -> [Kafka/Redis/Files] -> MMT-Operator (Web UI)
 | OS | Linux (x86_64) | Ubuntu 22.04 |
 | RAM | 100 MB | 2 GB+ (DPDK) |
 | Disk | ~50 MB | + space for reports |
-| Privileges | root or `CAP_NET_RAW` | root |
+| Privileges | root or `CAP_NET_RAW` (not needed in Docker) | root |
 
 ## Cross-references
 

--- a/skills/mmt-install/SKILL.md
+++ b/skills/mmt-install/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: mmt-install
+version: 1.0.0
+description: Install MMT-Probe and its dependencies from source, packages, or Docker
+---
+
+# MMT-Probe Installation
+
+Guide the user through installing MMT-Probe and all its dependencies.
+
+## Triggers
+
+Use this skill when the user asks to:
+- Install MMT-Probe or MMT-DPI
+- Set up the build environment
+- Compile MMT-Probe from source
+- Install dependencies (hiredis, librdkafka, mongo-c-driver, etc.)
+- Create .deb or .rpm packages
+- Run MMT-Probe via Docker
+
+## Prerequisites Check
+
+### Detect the OS
+
+```bash
+OS_ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
+OS_VERSION=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"')
+echo "Detected OS: $OS_ID $OS_VERSION"
+```
+
+### Required Software
+
+| Software    | Min Version | Purpose                      |
+|-------------|-------------|------------------------------|
+| GCC         | 4.9+        | C compiler                   |
+| G++         | 4.9+        | C++ compiler (static link)   |
+| GNU Make    | 3.81+       | Build system                 |
+| Git         | 2.0+        | Source code management       |
+| libconfuse  | any         | Configuration file parsing   |
+| libpcap     | any         | Packet capture               |
+| MMT-DPI     | 1.7.1+      | Deep Packet Inspection lib   |
+
+## Step 1: System Package Installation
+
+### Debian/Ubuntu
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential gcc g++ cpp cmake git curl
+sudo apt-get install -y libconfuse-dev libpcap-dev
+```
+
+### RHEL/CentOS/Fedora
+
+```bash
+sudo yum groupinstall -y "Development Tools"
+sudo yum install -y cmake git curl
+sudo yum install -y libconfuse-devel libpcap-devel
+```
+
+### Verify
+
+```bash
+gcc --version    # >= 4.9
+g++ --version    # >= 4.9
+make --version   # >= 3.81
+```
+
+## Step 2: Install MMT-DPI (Mandatory)
+
+MMT-DPI is the core deep packet inspection library. It **must** be installed before MMT-Probe.
+
+```bash
+TMP_DIR=$(mktemp -d -t mmt-setup-XXXXXXXXXX)
+cd "$TMP_DIR"
+git clone https://github.com/montimage/mmt-dpi.git mmt-dpi
+cd mmt-dpi/sdk
+make -j$(nproc)
+sudo make install
+sudo ldconfig
+```
+
+Verify: `ls /opt/mmt/dpi/lib/libmmt_core.so` and `ls /opt/mmt/dpi/include/`
+
+## Step 3: Optional Module Dependencies
+
+Only install libraries for the modules you need. Skip any you do not need.
+
+| Module             | Library           | Version | Install Command |
+|--------------------|-------------------|---------|-----------------|
+| `REDIS_MODULE`     | hiredis           | v1.0.2  | See 3a below    |
+| `KAFKA_MODULE`     | librdkafka        | v1.8.2  | See 3b below    |
+| `MONGODB_MODULE`   | mongo-c-driver    | 1.9.5   | See 3c below    |
+| `MQTT_MODULE`      | libpaho-mqtt      | any     | See 3d below    |
+| `SECURITY_MODULE`  | MMT-Security      | any     | See 3e below    |
+
+### 3a. Redis (hiredis v1.0.2)
+
+```bash
+cd "$TMP_DIR"
+git clone https://github.com/redis/hiredis.git hiredis
+cd hiredis && git checkout v1.0.2
+make -j$(nproc) && sudo make install && sudo ldconfig
+```
+
+### 3b. Kafka (librdkafka v1.8.2)
+
+```bash
+sudo apt-get install -y libsasl2-dev libssl-dev  # Debian/Ubuntu
+cd "$TMP_DIR"
+git clone https://github.com/edenhill/librdkafka.git librdkafka
+cd librdkafka && git checkout v1.8.2
+./configure && make -j$(nproc) && sudo make install && sudo ldconfig
+```
+
+### 3c. MongoDB (mongo-c-driver 1.9.5)
+
+```bash
+sudo apt-get install -y pkg-config libssl-dev libsasl2-dev  # Debian/Ubuntu
+cd "$TMP_DIR"
+curl -Lk --output mongo-c.tar.gz https://github.com/mongodb/mongo-c-driver/releases/download/1.9.5/mongo-c-driver-1.9.5.tar.gz
+tar xzf mongo-c.tar.gz && cd mongo-c-driver-1.9.5
+./configure --disable-automatic-init-and-cleanup
+make -j$(nproc) && sudo make install && sudo ldconfig
+```
+
+### 3d. MQTT (libpaho-mqtt)
+
+```bash
+sudo apt-get install -y libpaho-mqtt-dev  # Debian/Ubuntu
+```
+
+### 3e. MMT-Security
+
+```bash
+sudo apt-get install -y libxml2-dev libpcap-dev libconfuse-dev
+cd "$TMP_DIR"
+git clone https://github.com/Montimage/mmt-security.git mmt-security
+cd mmt-security
+make clean-all
+make -j1  # Must use single thread for header generation ordering
+sudo make install && sudo ldconfig
+```
+
+Verify: `ls /opt/mmt/security/lib/libmmt_security2.*`
+
+## Step 4: Compile MMT-Probe
+
+Navigate to the MMT-Probe source directory.
+
+### Minimal build (file output + PCAP only)
+
+```bash
+make clean
+make -j$(nproc) compile
+```
+
+### Build with selected modules
+
+Combine any module targets before `compile`:
+
+```bash
+make -j$(nproc) KAFKA_MODULE REDIS_MODULE SECURITY_MODULE PCAP_DUMP_MODULE QOS_MODULE SOCKET_MODULE compile
+```
+
+### Available module targets
+
+| Module Target             | Requires            |
+|---------------------------|----------------------|
+| `REDIS_MODULE`            | hiredis              |
+| `KAFKA_MODULE`            | librdkafka           |
+| `MONGODB_MODULE`          | mongo-c-driver       |
+| `MQTT_MODULE`             | libpaho-mqtt         |
+| `SECURITY_MODULE`         | MMT-Security + libxml2 |
+| `PCAP_DUMP_MODULE`        | (none)               |
+| `QOS_MODULE`              | (none)               |
+| `SOCKET_MODULE`           | (none)               |
+| `LTE_MODULE`              | (none)               |
+| `DYNAMIC_CONFIG_MODULE`   | (none)               |
+| `TCP_REASSEMBLY_MODULE`   | (none)               |
+| `HTTP_RECONSTRUCT_MODULE` | (none, implies TCP)  |
+| `FTP_RECONSTRUCT_MODULE`  | (none, implies TCP)  |
+
+### Build ALL modules
+
+```bash
+make -j$(nproc) ALL_MODULES compile
+```
+
+> Requires all optional libraries from Step 3 to be installed.
+
+### Build options
+
+| Option           | Effect                                       |
+|------------------|----------------------------------------------|
+| `DEBUG`          | Enable debug symbols (`-g -O0`)              |
+| `VERBOSE`        | Print detailed compilation commands          |
+| `STATIC_LINK`    | Embed MMT-DPI and MMT-Security into binary   |
+| `DISABLE_REPORT` | Skip DPI statistics                          |
+| `SIMPLE_REPORT`  | Minimal session reports (for MMT-Box)        |
+| `MMT_BASE=/path` | Custom install prefix (default: `/opt/mmt`)  |
+
+### DPDK capture (instead of PCAP)
+
+```bash
+export RTE_SDK=/path/to/dpdk
+export RTE_TARGET=build
+make -j$(nproc) DPDK_CAPTURE compile
+```
+
+## Step 5: Install
+
+```bash
+sudo make install
+# Or with modules:
+sudo make KAFKA_MODULE REDIS_MODULE SECURITY_MODULE install
+```
+
+Installs to `/opt/mmt/probe/` (or `$MMT_BASE/probe/`):
+- `bin/probe` — executable
+- `mmt-probe.conf` — configuration file
+- `result/report/online/` — default report output
+
+### Create packages (optional)
+
+```bash
+make deb                          # Debian .deb
+make KAFKA_MODULE REDIS_MODULE deb  # .deb with modules
+make rpm                          # RHEL .rpm
+```
+
+## Docker Alternative
+
+```bash
+# Pull pre-built image
+docker pull ghcr.io/montimage/mmt-probe:latest
+
+# Or build from source
+cd /path/to/mmt-probe
+docker build -t mmt-probe:local .
+```
+
+## Automated Script
+
+For a fully automated installation with all modules on Debian/Ubuntu:
+
+```bash
+sudo ./script/install-from-source.sh
+```
+
+This installs all dependencies, compiles with all modules, and creates a `.deb` package.
+
+## Verification
+
+```bash
+./probe -v                  # Print version (e.g., mmt-probe 1.6.0)
+./probe -h                  # Print usage help
+sudo ./probe -t test/UA-Exp01.pcap -Xfile-output.output-dir=/tmp/mmt-test/
+ls -la /tmp/mmt-test/       # Should contain report files
+ldd /opt/mmt/probe/bin/probe  # All libraries resolved (no "not found")
+```
+
+## Troubleshooting
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `ERROR: Not found MMT-DPI at folder /opt/mmt/dpi` | MMT-DPI not installed | Install MMT-DPI (Step 2) |
+| `Not found MMT-Security at /opt/mmt/security` | MMT-Security missing | Install it (Step 3e) or remove `SECURITY_MODULE` |
+| `-lhiredis` not found | hiredis missing | Install (Step 3a) or remove `REDIS_MODULE` |
+| `-lrdkafka` not found | librdkafka missing | Install (Step 3b) or remove `KAFKA_MODULE` |
+| `-lmongoc-1.0` not found | mongo-c-driver missing | Install (Step 3c) or remove `MONGODB_MODULE` |
+| `-lpaho-mqtt3c` not found | libpaho-mqtt missing | Install (Step 3d) or remove `MQTT_MODULE` |
+| `error while loading shared libraries` | Library not in LD path | Run `sudo ldconfig` |
+| Library path issues | `/usr/local/lib` not in linker path | `ldconfig -p \| grep <lib>` to check |
+
+## Important Notes
+
+- Always run `make clean` before recompiling with different modules.
+- Run `sudo ldconfig` after installing any shared library.
+- DPDK mode requires hugepage allocation: `echo 1024 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages`
+
+## Cross-references
+
+- After installation, use `/mmt-configure` to set up configuration.
+- To run the probe, use `/mmt-operate`.
+- For general help, use `/mmt-help`.

--- a/skills/mmt-operate/SKILL.md
+++ b/skills/mmt-operate/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: mmt-operate
+version: 1.0.0
+description: Run MMT-Probe, understand report output, use dynamic control, and troubleshoot operations
+---
+
+# MMT-Probe Operation
+
+Guide the user through running MMT-Probe, interpreting its output, and controlling it at runtime.
+
+## Triggers
+
+Use this skill when the user asks to:
+- Run or start MMT-Probe
+- Analyze a PCAP file
+- Understand report output or data format
+- Check probe status or logs
+- Control the probe at runtime (start, stop, update)
+- Troubleshoot operational issues (no output, packet drops, etc.)
+
+## Execution Modes
+
+### Live capture on interface
+
+```bash
+sudo ./probe -i eth0
+```
+
+### Offline PCAP analysis
+
+```bash
+sudo ./probe -t /path/to/capture.pcap
+```
+
+### With a configuration file
+
+```bash
+sudo ./probe -c /path/to/mmt-probe.conf
+```
+
+### As a systemd service
+
+Available when installed to `/opt/mmt/probe/`.
+
+```bash
+sudo systemctl start mmt-probe
+sudo systemctl stop mmt-probe
+sudo systemctl status mmt-probe
+```
+
+### With Docker
+
+```bash
+# Live capture
+docker run --network=host ghcr.io/montimage/mmt-probe:latest \
+    mmt-probe -i eth0 -Xfile-output.enable=true
+
+# PCAP file analysis
+docker run -v /path/to/pcaps:/data ghcr.io/montimage/mmt-probe:latest \
+    mmt-probe -t /data/capture.pcap
+```
+
+### Quick test
+
+```bash
+sudo ./probe -t test/UA-Exp01.pcap -Xfile-output.output-dir=/tmp/mmt-test/
+ls -la /tmp/mmt-test/
+```
+
+## CLI Flags Reference
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `-v` | Print version info and exit | `./probe -v` |
+| `-h` | Print usage help and exit | `./probe -h` |
+| `-c <file>` | Use specific config file | `./probe -c my.conf` |
+| `-t <pcap>` | Offline mode: analyze PCAP file | `./probe -t capture.pcap` |
+| `-i <iface>` | Online mode: capture on interface | `./probe -i eth0` |
+| `-X <key>=<val>` | Override a config parameter | `-Xthread-nb=4` |
+| `-x` | List all overridable parameters | `./probe -x` |
+
+Multiple `-X` flags can be combined:
+
+```bash
+sudo ./probe -i eth0 -Xfile-output.enable=true -Xsecurity.enable=true -Xthread-nb=2
+```
+
+## Report Types
+
+All reports share a common header:
+
+| Column | Name | Description |
+|--------|------|-------------|
+| 1 | format_id | Report type identifier |
+| 2 | probe_id | Probe instance identifier |
+| 3 | source | Interface name or PCAP file path |
+| 4 | timestamp | Seconds.micros (packet time or real time for id=201) |
+
+### Report Type Summary
+
+| Format ID | Name | Description | Channel |
+|-----------|------|-------------|---------|
+| 1 | Startup | Sent once at probe start (version info) | — |
+| 10 | Security | Security alerts from MMT-Security | `security.report` |
+| 30 | License | License status reports | `license.stat` |
+| 99 | Protocol Stats | Protocol/app statistics (non-session) | — |
+| 100 | Session | Per-flow session statistics | `session.report` |
+| 200 | Status | Probe liveness + packet counts (online only) | — |
+| 201 | System Info | CPU and memory usage of the host | — |
+| 301 | HTTP Reconstruct | Metadata of reconstructed HTTP files | — |
+| 400 | eNodeB Topology | LTE element add/remove events | — |
+| 401 | eNodeB QoS | UE dedicated bearer allocation | — |
+| 1000 | Event | Custom event-triggered reports | `event.report` |
+
+### Status Report (ID 200)
+
+Reports probe liveness during live capture. Created every `stats-period` seconds.
+
+| Col | Name | Description |
+|-----|------|-------------|
+| 5 | nic-pkt | Packets received by NIC |
+| 6 | nic-lost | Packets dropped by NIC |
+| 7 | mmt-pkt | Packets received by MMT |
+| 8 | mmt-lost | Packets dropped by MMT |
+| 9 | mmt-bytes | Bytes received by MMT |
+| 10 | mmt-b-lost | Bytes dropped by MMT |
+
+### System Info Report (ID 201)
+
+| Col | Name | Description |
+|-----|------|-------------|
+| 5 | user_cpu | % CPU in user mode |
+| 6 | sys_cpu | % CPU in system mode |
+| 7 | idle | % CPU idle |
+| 8 | avail_mem | Available memory (kB) |
+| 9 | total_mem | Total memory (kB) |
+
+Example: `201,3,"eth0",1498126191.034157,98.57,0.72,0.72,1597680,2048184`
+
+### Session Report (ID 100)
+
+Per-flow statistics with 41 common columns including:
+- Client/server IP and MAC addresses (cols 20-23)
+- Session ID, ports (cols 24-26)
+- Handshake time, app response time, data transfer time (cols 28-30)
+- Client/server RTT min/max/avg (cols 31-36)
+- TCP retransmissions (cols 37-38)
+- Sub-format ID (col 39) determining extension fields
+
+#### Session sub-formats
+
+| Sub-format | Protocol | Extension Fields |
+|------------|----------|------------------|
+| 0 | Default | (none) |
+| 1 | HTTP | Response time, hostname, MIME, referrer, CDN, URI, method, status |
+| 2 | SSL | Server name, CDN flag |
+| 3 | RTP | Packet loss rate, burstiness, max jitter, order errors |
+| 4 | FTP | Username, password, file size, file name, direction |
+| 5 | GTP | Outer IP src/dst, TEIDs array |
+
+### Event Report (ID 1000)
+
+| Col | Name | Description |
+|-----|------|-------------|
+| 5 | event-id | String identifier of the event-report |
+| 6 | event | Event attribute value that triggered the report |
+| 7+ | attributes | Registered attributes (variable count) |
+
+Example: `1000,3,"./file.pcap",1399407481.189781,1,172.19.190.67,172.19.190.67`
+
+### Security Report (ID 10)
+
+| Col | Name | Description |
+|-----|------|-------------|
+| 5 | property_id | Rule identifier number |
+| 6 | verdict | `detected`, `not_detected`, `respected`, `not_respected`, `unknown` |
+| 7 | type | `attack`, `security`, `test`, `evasion` |
+| 8 | cause | Description of the property |
+| 9 | history | JSON object with events leading to the verdict |
+
+## Output Channel Quick Reference
+
+Reports can be directed to specific output channels using `output-channel`:
+
+```
+output-channel = {file}           # File only
+output-channel = {redis, kafka}   # Redis and Kafka
+output-channel = {file, mongodb, socket, mqtt}  # Multiple
+output-channel = {stdout}         # Console output
+output-channel = {}               # Default (file)
+```
+
+Each channel must be globally enabled (e.g., `kafka-output.enable = true`) for the routing to work.
+
+## Dynamic Control
+
+Requires: `DYNAMIC_CONFIG_MODULE` and `dynamic-config.enable = true`
+
+Control the probe at runtime via Unix domain socket (default: `/tmp/mmt.sock`).
+
+### Start processing
+
+```bash
+printf "start\0" | sudo nc -U /tmp/mmt.sock
+```
+
+Returns: `0`=success, `1`=already running, `2`=error
+
+### Stop processing
+
+```bash
+printf "stop\0" | sudo nc -U /tmp/mmt.sock
+```
+
+Returns: `0`=success, `1`=not running, `2`=error
+
+### Update configuration
+
+```bash
+printf 'update{\ninput.source="enp0s3"\ninput.mode=ONLINE\n}\0' | sudo nc -U /tmp/mmt.sock
+```
+
+Returns: `0`=updated (no restart), `1`=updated (restarted), `2`=syntax error, `3`=internal error
+
+### List parameters
+
+```bash
+printf 'ls\0' | sudo nc -U /tmp/mmt.sock
+```
+
+## Viewing Logs
+
+```bash
+# Systemd service logs
+journalctl -t mmt-probe
+
+# Follow logs in real time
+journalctl -t mmt-probe -f
+
+# Logs from last hour
+journalctl -t mmt-probe --since "1 hour ago"
+```
+
+## Performance Tips
+
+1. **Increase threads** for high-throughput: `-Xthread-nb=4`
+2. **Increase queue size** to reduce drops: `-Xthread-queue=524288`
+3. **Use BPF filters** to reduce processing load: `-Xinput.pcap-filter="tcp port 80"`
+4. **Increase cache** for batch efficiency: `-Xoutput.cache-max=500000`
+5. **Disable unused reports** to reduce overhead:
+   - `-Xsession-report.http=false -Xsession-report.rtp=false`
+6. **Use DPDK** for 10Gbps+ links (requires DPDK build)
+
+## Troubleshooting Operations
+
+| Problem | Possible Cause | Solution |
+|---------|---------------|----------|
+| No output files | `file-output.enable` is false | `-Xfile-output.enable=true` |
+| No output files | Wrong output directory | Check `-Xfile-output.output-dir` path exists |
+| Probe exits immediately | License check failed | Remove `LICENSE_MODULE` or provide `license.key` |
+| High `nic-lost` in status reports | NIC buffer too small | Increase `input.buffer-size` |
+| High `mmt-lost` in status reports | Processing too slow | Increase `thread-nb` and `thread-queue` |
+| Packet drops with multi-thread | Thread queue full | Increase `thread-queue` value |
+| `Permission denied` on interface | Missing root/capabilities | Run with `sudo` or set `CAP_NET_RAW` |
+| `error while loading shared libraries` | Library path issue | Run `sudo ldconfig` |
+| High memory usage | Too many active sessions | Reduce `session-timeout` values |
+| Reports not in expected channel | Channel not enabled | Ensure global `<channel>-output.enable = true` |
+
+## Cross-references
+
+- To install MMT-Probe, use `/mmt-install`.
+- To configure the probe, use `/mmt-configure`.
+- For general help and architecture, use `/mmt-help`.


### PR DESCRIPTION
## Summary

- Add 4 Claude Code skills (`/mmt-install`, `/mmt-configure`, `/mmt-operate`, `/mmt-help`) in `skills/` to provide domain-specific guidance for MMT-Probe installation, configuration, operation, and troubleshooting
- Add comprehensive AI agent setup instructions (`agents-instructions.md`) covering the full installation workflow
- All skills are Docker-aware: commands use `$SUDO` variable pattern or show host vs container variants, with `sudo: command not found` in troubleshooting tables

## Test plan

- [ ] Verify each `SKILL.md` has valid YAML frontmatter (name, version, description)
- [ ] Verify each skill file is under 500 lines
- [ ] Verify the `skills/` directory structure matches: `skills/{mmt-install,mmt-configure,mmt-operate,mmt-help}/SKILL.md`
- [ ] Confirm all referenced project files exist (e.g., `mmt-probe.conf`, `test/UA-Exp01.pcap`, `script/install-from-source.sh`)
- [ ] Test skill invocation in Claude Code (e.g., `/mmt-install`, `/mmt-help`)
- [ ] Verify Docker instructions work without `sudo` in a container environment