### PR TITLE
Avoid CPU draining when no packet

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -93,11 +93,16 @@ static inline void context_print_traffic_stat( const probe_context_t *context, c
 	}
 
 
-	log_write_dual( LOG_INFO, "%s%% dropped by NIC %.4f, by MMT %.4f", message,
-			context->traffic_stat.nic.receive == 0? 0 :
-					(context->traffic_stat.nic.drop * 100.0 / context->traffic_stat.nic.receive ),
-			context->traffic_stat.nic.receive == 0? 0 :
-					(context->traffic_stat.mmt.packets.drop * 100.0 / context->traffic_stat.nic.receive )
+	uint64_t total_pkt = context->traffic_stat.nic.receive;
+	uint64_t total_dropped_pkt = context->traffic_stat.nic.drop + context->traffic_stat.mmt.packets.drop;
+
+	log_write_dual( LOG_INFO, "got %"PRIu64" packets, processed %"PRIu64" packets (%"PRIu64" bytes), dropped %"PRIu64" packets (%.2f%%)",
+			total_pkt,
+			context->traffic_stat.mmt.packets.receive,
+			context->traffic_stat.mmt.bytes.receive,
+			total_dropped_pkt,
+			total_dropped_pkt == 0 ? 0:
+					( total_dropped_pkt * 100.0 / total_pkt )
 	 );
 }
 

--- a/src/modules/packet_capture/pcap/pcap_capture.c
+++ b/src/modules/packet_capture/pcap/pcap_capture.c
@@ -358,7 +358,20 @@ static inline void _pcap_capture_release( probe_context_t *context ){
 	mmt_probe_free( context->modules.pcap );
 }
 
+static inline int _sleep(pcap_t *pcap ){
+	int pcap_fd = pcap_get_selectable_fd( pcap );
 
+	fd_set rfds;
+	FD_ZERO(&rfds);
+	FD_SET(pcap_fd, &rfds);
+
+	struct timeval tv;
+	tv.tv_sec = 0;
+	tv.tv_usec = 100*1000*1000; //100 ms
+
+	int ret = select(pcap_fd + 1, &rfds, NULL, NULL, &tv);
+	return ret;
+}
 
 //public API
 void pcap_capture_start( probe_context_t *context ){
@@ -538,7 +551,8 @@ void pcap_capture_start( probe_context_t *context ){
 				// such as, worker_on_timer_stat_period, worker_on_timer_sample_file_period
 				_got_a_packet( (u_char*) context, NULL, NULL );
 				//we need to small sleep here to wait for a new packet
-				nanosleep( (const struct timespec[]){{0, 100000L}}, NULL );
+				//nanosleep( (const struct timespec[]){{0, 100*1000L}}, NULL );
+				_sleep( pcap );
 			}
 		}else if( ret > 0 )
 			continue;

--- a/src/modules/packet_capture/pcap/pcap_capture.c
+++ b/src/modules/packet_capture/pcap/pcap_capture.c
@@ -318,12 +318,13 @@ static inline void _print_pcap_stats( const probe_context_t *context ){
 		}else{
 			u_int pkt_received = pcs.ps_recv;
 			u_int pkt_dropped  = pcs.ps_ifdrop + pcs.ps_drop;
-			log_write_dual( LOG_INFO, "System received %d packets, dropped %d (%.2f%% = %.2f%% by NIC + %.2f%% by kernel)",
+			log_write_dual( LOG_INFO, "System received %d packets, dropped %d (%.2f%% = %.2f%% by NIC + %.2f%% by Kernel)",
 					pkt_received,
 					pkt_dropped,
-					pkt_dropped   * 100.0 / pkt_received,
-					pcs.ps_ifdrop * 100.0 / pkt_received,
-					pcs.ps_drop   * 100.0 / pkt_received);
+					pkt_received == 0? 0 : (pkt_dropped   * 100.0 / pkt_received),
+					pkt_received == 0? 0 : (pcs.ps_ifdrop * 100.0 / pkt_received),
+					pkt_received == 0? 0 : (pcs.ps_drop   * 100.0 / pkt_received)
+			);
 		}
 	}
 }

--- a/src/worker.c
+++ b/src/worker.c
@@ -72,7 +72,7 @@ void worker_print_common_statistics( const probe_context_t *context ){
 		log_write_dual( LOG_INFO, "MMT processed %"PRIu64" packets, dropped %"PRIu64" packets (%.2f%%)"SEC_MSG_FORMAT,
 				context->smp[0]->stat.pkt_processed,
 				context->smp[0]->stat.pkt_dropped,
-				context->smp[0]->stat.pkt_dropped * 100.0 / (context->smp[0]->stat.pkt_processed + context->smp[0]->stat.pkt_dropped)
+				PERCENTAGE(context->smp[0]->stat.pkt_dropped, ((context->smp[0]->stat.pkt_processed + context->smp[0]->stat.pkt_dropped)))
 #ifdef SECURITY_MODULE
 				,context->smp[0]->stat.alert_generated
 #endif


### PR DESCRIPTION
Previously Probe sleeps 100 microseconds when no packet coming. This tiny interval requires MMT to continuously pulling NIC. This adapts for a high-performance but consumes CPU when no (or few) packets to be processing.

This commit use "select" to sleep maximally 100 milliseconds if no packets. If having a packet, this "select" is broken (event 100 ms is not terminated). 100 ms is selected to  regularly send report to outputs.

Within this modification, when no packets for processing, Probe consumes almost no CPU (before ~9%).